### PR TITLE
Fixes default children prop behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Yet another Vue treeview component.",
   "author": "Gregg Rapoza <grapoza@gmail.com>",
   "license": "MIT",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "browser": "index.js",
   "repository": {
     "url": "https://github.com/grapoza/vue-tree",

--- a/src/components/TreeViewNode.vue
+++ b/src/components/TreeViewNode.vue
@@ -269,7 +269,7 @@
         return this.model.children.length > 0 && this.model.expandable;
       },
       childrenPropName() {
-        return this.childrenPropNames.find(pn => Array.isArray(this.model[pn]));
+        return this.childrenPropNames.find(pn => Array.isArray(this.model[pn])) || 'children';
       },
       customClasses() {
         return (this.model.customizations || {}).classes || {};
@@ -326,8 +326,8 @@
         this.$_treeViewNode_assignDefaultProps(this.modelDefaults, this.model);
 
         // Set expected properties if not provided
-        if (!Array.isArray(this.model.children)) {
-          this.$set(this.model, 'children', []);
+        if (!Array.isArray(this.model[this.childrenPropName])) {
+          this.$set(this.model, this.childrenPropName, []);
         }
         if (typeof this.model.expandable !== 'boolean') {
           this.$set(this.model, 'expandable', true);

--- a/tests/unit/TreeViewNode.spec.js
+++ b/tests/unit/TreeViewNode.spec.js
@@ -719,20 +719,38 @@ describe('TreeViewNode.vue', () => {
 
   describe('when childrenPropNames is specified', () => {
 
-    beforeEach(() => {
-      let defaultProps = getDefaultPropsData();
-      wrapper = createWrapper(Object.assign(defaultProps, {
-        childrenPropNames: ['nope', 'children'],
-        initialModel: generateNodes(['sf', ['s', 's']], defaultProps.radioGroupValues)[0]
-      }));
+    describe('and a valid-children model property is specified', () => {
+
+      beforeEach(() => {
+        let defaultProps = getDefaultPropsData();
+        wrapper = createWrapper(Object.assign(defaultProps, {
+          childrenPropNames: ['nope', 'children'],
+          initialModel: generateNodes(['sf', ['s', 's']], defaultProps.radioGroupValues)[0]
+        }));
+      });
+
+      it('has a childrenPropName matching the first-avilable valid-children model property', () => {
+        expect(wrapper.vm.childrenPropName).to.equal('children');
+      });
+
+      it('has a children list of the first-avilable model[childrenPropName] property', () => {
+        expect(wrapper.vm.model.children.length).to.equal(2);
+      });
     });
 
-    it('has a childrenPropName matching the first-avilable valid-children model property', () => {
-      expect(wrapper.vm.childrenPropName).to.equal('children');
-    });
+    describe('and a valid-children model property is not specified', () => {
 
-    it('has a children list of the first-avilable model[childrenPropName] property', () => {
-      expect(wrapper.vm.model.children.length).to.equal(2);
+      beforeEach(() => {
+        let defaultProps = getDefaultPropsData();
+        wrapper = createWrapper(Object.assign(defaultProps, {
+          childrenPropNames: ['nope', 'steve'],
+          initialModel: generateNodes(['sf', ['s', 's']], defaultProps.radioGroupValues)[0]
+        }));
+      });
+
+      it('has a childrenPropName of "children"', () => {
+        expect(wrapper.vm.childrenPropName).to.equal('children');
+      });
     });
   });
 });


### PR DESCRIPTION
Fixing the default child prop name, it is now `children` if no valid prop name is found. This can be used to default the creation of an empty children prop if needed.