### PR TITLE
Reswizzle tree model

### DIFF
--- a/docsrc/demo/addRemove.md
+++ b/docsrc/demo/addRemove.md
@@ -35,7 +35,7 @@ This page demonstrates adding and removing nodes. [See the data used](./addRemov
       methods: {
         addChildCallback(parentModel) {
           this.childCounter++;
-          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, deletable: true });
+          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, treeNodeSpec: { deletable: true } });
         }
       }
     }).$mount('#app');

--- a/docsrc/demo/basic.js
+++ b/docsrc/demo/basic.js
@@ -2,84 +2,94 @@ export default [
   {
     id: 'node1',
     label: 'My First Node',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox1'
-    },
-    state: {
-      expanded: false,
-      selected: false,
+    children: [],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
       input: {
-        value: false,
-        disabled: false
+        type: 'checkbox',
+        name: 'checkbox1'
+      },
+      state: {
+        expanded: false,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
       }
-    },
-    children: []
+    }
   },
   {
     id: 'node2',
     label: 'My Second Node',
-    title: 'You can add a title to an input node.',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox2'
-    },
-    state: {
-      expanded: true,
-      selected: false,
-      input: {
-        value: false,
-        disabled: false
-      }
-    },
     children: [
       {
         id: 'subnode1',
         label: 'This is a subnode',
-        title: 'You can add a title to a text node.',
-        expandable: true,
-        selectable: true,
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          title: 'You can add a title to a text node.',
+          expandable: true,
+          selectable: true,
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       },
       {
         id: 'subnode2',
         label: 'This is a checkable, checked subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'checkbox',
-          name: 'checkbox3'
-        },
-        state: {
-          expanded: false,
-          selected: false,
-          input: {
-            value: true,
-            disabled: true
-          }
-        },
         children: [
           {
             id: 'subsubnode1',
             label: 'An even deeper node',
             children: [],
-            expandable: true,
-            selectable: true,
-            state: {
-              expanded: false,
-              selected: false
+            treeNodeSpec: {
+              expandable: true,
+              selectable: true,
+              state: {
+                expanded: false,
+                selected: false
+              }
             }
           }
-        ]
+        ],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'checkbox',
+            name: 'checkbox3'
+          },
+          state: {
+            expanded: false,
+            selected: false,
+            input: {
+              value: true,
+              disabled: true
+            }
+          }
+        }
       }
-    ]
+    ],
+    treeNodeSpec: {
+      title: 'You can add a title to an input node.',
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'checkbox',
+        name: 'checkbox2'
+      },
+      state: {
+        expanded: true,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
+      }
+    }
   }
 ];

--- a/docsrc/demo/customStyles.js
+++ b/docsrc/demo/customStyles.js
@@ -1,40 +1,40 @@
 let defaultData = [
-    {
-        id: 'rootNode',
-        label: 'Root Node',
-        children: [
-            {
-                id: 'subNode',
-                label: 'Subnode'
-            }
-        ]
-    }
+  {
+    id: 'rootNode',
+    label: 'Root Node',
+    children: [
+      {
+        id: 'subNode',
+        label: 'Subnode'
+      }
+    ]
+  }
 ];
 
 let classbasedData = [
-    {
-        id: 'classNode',
-        label: 'Root Node',
-        children: [
-            {
-                id: 'subNode',
-                label: 'Subnode'
-            }
-        ]
-    }
+  {
+    id: 'classNode',
+    label: 'Root Node',
+    children: [
+      {
+        id: 'subNode',
+        label: 'Subnode'
+      }
+    ]
+  }
 ];
 
 let grayData = [
-    {
-        id: 'grayNode',
-        label: 'Root Node',
-        children: [
-            {
-                id: 'subNode',
-                label: 'Subnode'
-            }
-        ]
-    }
+  {
+    id: 'grayNode',
+    label: 'Root Node',
+    children: [
+      {
+        id: 'subNode',
+        label: 'Subnode'
+      }
+    ]
+  }
 ];
 
 export { defaultData, classbasedData, grayData };

--- a/docsrc/demo/customStyles.md
+++ b/docsrc/demo/customStyles.md
@@ -39,7 +39,7 @@ First, let's look at the default styles. There's not much to see here, since the
       methods: {
         addChildCallback(parentModel) {
           this.childCounter++;
-          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, deletable: true });
+          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, treeNodeSpec: { deletable: true } });
         }
       }
     }).$mount('#app-default');
@@ -83,7 +83,7 @@ Some simple customizations can be done by applying custom classes to various par
       methods: {
         addChildCallback(parentModel) {
           this.childCounter++;
-          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, deletable: true });
+          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, treeNodeSpec: { deletable: true } });
         }
       }
     }).$mount('#app-classbased');
@@ -130,7 +130,7 @@ In this example, a treeview has been given a `skin-class` prop value of `graysca
       methods: {
         addChildCallback(parentModel) {
           this.childCounter++;
-          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, deletable: true });
+          return Promise.resolve({ id: `child-node${this.childCounter}`, label: `Added Child ${this.childCounter}`, treeNodeSpec: { deletable: true } });
         }
       }
     }).$mount('#app-gray');

--- a/docsrc/demo/radioBasic.js
+++ b/docsrc/demo/radioBasic.js
@@ -2,63 +2,71 @@ export default [
   {
     id: 'node1',
     label: 'My First Node',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'radio',
-      name: 'radio1',
-      value: 'aValueToSubmit'
-    },
-    state: {
-      expanded: false,
-      selected: false
-    },
-    children: []
+    children: [],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'radio',
+        name: 'radio1',
+        value: 'aValueToSubmit'
+      },
+      state: {
+        expanded: false,
+        selected: false
+      }
+    }
   },
   {
     id: 'node2',
     label: 'My Second Node',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'radio',
-      name: 'radio1'
-    },
-    state: {
-      expanded: true,
-      selected: false
-    },
     children: [
       {
         id: 'subnode1',
         label: 'This is a subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'radio',
-          name: 'radio2'
-        },
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'radio',
+            name: 'radio2'
+          },
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       },
       {
         id: 'subnode2',
         label: 'This is a checkable, checked subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'radio',
-          name: 'radio2'
-        },
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'radio',
+            name: 'radio2'
+          },
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       }
-    ]
+    ],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'radio',
+        name: 'radio1'
+      },
+      state: {
+        expanded: true,
+        selected: false
+      }
+    }
   }
 ];

--- a/docsrc/demo/selection.js
+++ b/docsrc/demo/selection.js
@@ -2,72 +2,47 @@ export default [
   {
     id: 'node1',
     label: 'My First Node',
-    expandable: true,
-    selectable: true,
-    deletable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox1'
-    },
-    state: {
-      expanded: false,
-      selected: false,
+    children: [],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      deletable: true,
       input: {
-        value: false,
-        disabled: false
+        type: 'checkbox',
+        name: 'checkbox1'
+      },
+      state: {
+        expanded: false,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
       }
-    },
-    children: []
+    }
   },
   {
     id: 'node2',
     label: 'My Second Node',
-    title: 'My second node, and its fantastic title',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox2'
-    },
-    state: {
-      expanded: true,
-      selected: false,
-      input: {
-        value: false,
-        disabled: false
-      }
-    },
     children: [
       {
         id: 'subnode1',
         label: 'This is a subnode',
-        title: 'Even non-input nodes should get a title.',
-        expandable: true,
-        selectable: true,
-        deletable: true,
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          title: 'Even non-input nodes should get a title.',
+          expandable: true,
+          selectable: true,
+          deletable: true,
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       },
       {
         id: 'subnode2',
         label: 'This is a checkable, checked subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'checkbox',
-          name: 'checkbox3'
-        },
-        state: {
-          expanded: false,
-          selected: false,
-          input: {
-            value: true,
-            disabled: true
-          }
-        },
         children: [
           {
             id: 'subsubnode1',
@@ -84,8 +59,41 @@ export default [
               return Promise.resolve(entry ? { id: entry, label: entry, deletable: true, selectable: true } : null);
             }
           }
-        ]
+        ],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'checkbox',
+            name: 'checkbox3'
+          },
+          state: {
+            expanded: false,
+            selected: false,
+            input: {
+              value: true,
+              disabled: true
+            }
+          }
+        }
       }
-    ]
+    ],
+    treeNodeSpec: {
+      title: 'My second node, and its fantastic title',
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'checkbox',
+        name: 'checkbox2'
+      },
+      state: {
+        expanded: true,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
+      }
+    }
   }
 ];

--- a/docsrc/demo/slots.js
+++ b/docsrc/demo/slots.js
@@ -2,35 +2,56 @@ export default [
   {
     id: 'node1',
     label: 'Checkbox Node',
-    input: {
-      type: 'checkbox',
-      name: 'checkbox1'
-    },
-    state: {
+    children: [],
+    treeNodeSpec: {
+      customizations: {
+        classes: {
+          treeViewNode: 'beep'
+        }
+      },
       input: {
-        value: false,
-        disabled: false
+        type: 'checkbox',
+        name: 'checkbox1'
+      },
+      state: {
+        input: {
+          value: false,
+          disabled: false
+        }
       }
-    },
-    children: []
+    }
   },
   {
     id: 'node2',
     label: 'Radiobutton Node',
-    input: {
-      type: 'radio',
-      name: 'radiobutton1'
-    },
-    state: {
+    treeNodeSpec: {
+      customizations: {
+        classes: {
+          treeViewNode: 'boop'
+        }
+      },
       input: {
-        value: false,
-        disabled: false
+        type: 'radio',
+        name: 'radiobutton1'
+      },
+      state: {
+        input: {
+          value: false,
+          disabled: false
+        }
       }
     }
   },
   {
     id: 'node3',
     label: 'Text Node',
-    children: []
+    children: [],
+    treeNodeSpec: {
+      customizations: {
+        classes: {
+          treeViewNode: 'plop'
+        }
+      },
+    }
   }
 ];

--- a/docsrc/demo/slots.md
+++ b/docsrc/demo/slots.md
@@ -12,28 +12,28 @@ This page demonstrates slotted content. [See the data used](./slots.js).
 <div id="app">
     <tree id="customtree" :initial-model="model">
         <template v-slot:text="{ model, customClasses }">
-            <span>{{ model.label }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
+            <span>{{ model[model.treeNodeSpec.labelProperty] }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
         </template>
         <template v-slot:checkbox="{ model, customClasses, inputId, checkboxChangeHandler }">
-            <label :for="inputId" :title="model.title">
+            <label :for="inputId" :title="model.treeNodeSpec.title">
                 <input :id="inputId"
                        type="checkbox"
-                       :disabled="model.state.input.disabled"
-                       v-model="model.state.input.value"
+                       :disabled="model.treeNodeSpec.state.input.disabled"
+                       v-model="model.treeNodeSpec.state.input.value"
                        v-on:change="checkboxChangeHandler" />
-                <marquee style="max-width: 6rem">{{ model.label }}. Custom Classes: {{ JSON.stringify(customClasses) }}</marquee>
+                <marquee style="max-width: 6rem">{{ model[model.treeNodeSpec.labelProperty] }}. Custom Classes: {{ JSON.stringify(customClasses) }}</marquee>
             </label>
         </template>
         <template v-slot:radio="{ model, customClasses, inputId, inputModel, radioChangeHandler }">
-            <label :for="inputId" :title="model.title">
+            <label :for="inputId" :title="model.treeNodeSpec.title">
                 <input :id="inputId"
                        type="radio"
-                       :name="model.input.name"
-                       :value="model.input.value"
-                       :disabled="model.state.input.disabled"
+                       :name="model.treeNodeSpec.input.name"
+                       :value="model.treeNodeSpec.input.value"
+                       :disabled="model.treeNodeSpec.state.input.disabled"
                        v-model="inputModel"
                        v-on:change="radioChangeHandler" />
-                <span style="font-weight: bolder">{{ model.label }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
+                <span style="font-weight: bolder">{{ model[model.treeNodeSpec.labelProperty] }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
             </label>
         </template>
     </tree>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Yet another Vue treeview component.",
   "author": "Gregg Rapoza <grapoza@gmail.com>",
   "license": "MIT",
-  "version": "1.3.7",
+  "version": "2.0.0",
   "browser": "index.js",
   "repository": {
     "url": "https://github.com/grapoza/vue-tree",

--- a/src/components/TreeViewNode.vue
+++ b/src/components/TreeViewNode.vue
@@ -24,11 +24,11 @@
               v-if="canExpand"
               aria-hidden="true"
               tabindex="-1"
-              :title="model.expanderTitle"
+              :title="model.treeNodeSpec.expanderTitle"
               class="tree-view-node-self-expander"
               :class="[customClasses.treeViewNodeSelfExpander,
-                       model.state.expanded ? 'tree-view-node-self-expanded' : '',
-                       model.state.expanded ? customClasses.treeViewNodeSelfExpanded : '']"
+                       model.treeNodeSpec.state.expanded ? 'tree-view-node-self-expanded' : '',
+                       model.treeNodeSpec.state.expanded ? customClasses.treeViewNodeSelfExpanded : '']"
               @click="$_treeViewNode_onExpandedChange">
               <i class="tree-view-node-self-expanded-indicator"
                  :class="customClasses.treeViewNodeSelfExpandedIndicator"></i></button>
@@ -38,7 +38,7 @@
 
       <!-- Inputs and labels -->
       <!-- Checkbox -->
-      <slot v-if="model.input && model.input.type === 'checkbox'"
+      <slot v-if="model.treeNodeSpec.input && model.treeNodeSpec.input.type === 'checkbox'"
             name="checkbox"
             :model="model"
             :customClasses="customClasses"
@@ -46,7 +46,7 @@
             :checkboxChangeHandler="$_treeViewNode_onCheckboxChange">
 
         <label :for="inputId"
-               :title="model.title"
+               :title="model.treeNodeSpec.title"
                class="tree-view-node-self-label"
                :class="customClasses.treeViewNodeSelfLabel">
 
@@ -55,8 +55,8 @@
                  class="tree-view-node-self-input tree-view-node-self-checkbox"
                  :class="[customClasses.treeViewNodeSelfInput, customClasses.treeViewNodeSelfCheckbox]"
                  type="checkbox"
-                 :disabled="model.state.input.disabled"
-                 v-model="model.state.input.value"
+                 :disabled="model.treeNodeSpec.state.input.disabled"
+                 v-model="model.treeNodeSpec.state.input.value"
                  @change="$_treeViewNode_onCheckboxChange" />
 
           {{ model[labelPropName] }}
@@ -64,16 +64,16 @@
       </slot>
 
       <!-- Radiobutton -->
-      <slot v-else-if="model.input && model.input.type === 'radio'"
+      <slot v-else-if="model.treeNodeSpec.input && model.treeNodeSpec.input.type === 'radio'"
             name="radio"
             :model="model"
             :customClasses="customClasses"
             :inputId="inputId"
-            :inputModel="radioGroupValues[model.input.name]"
+            :inputModel="radioGroupValues[model.treeNodeSpec.input.name]"
             :radioChangeHandler="$_treeViewNode_onRadioChange">
 
         <label :for="inputId"
-               :title="model.title"
+               :title="model.treeNodeSpec.title"
                class="tree-view-node-self-label"
                :class="customClasses.treeViewNodeSelfLabel">
 
@@ -82,10 +82,10 @@
                  class="tree-view-node-self-input tree-view-node-self-radio"
                  :class="[customClasses.treeViewNodeSelfInput, customClasses.treeViewNodeSelfRadio]"
                  type="radio"
-                 :name="model.input.name"
-                 :value="model.input.value"
-                 :disabled="model.state.input.disabled"
-                 v-model="radioGroupValues[model.input.name]"
+                 :name="model.treeNodeSpec.input.name"
+                 :value="model.treeNodeSpec.input.value"
+                 :disabled="model.treeNodeSpec.state.input.disabled"
+                 v-model="radioGroupValues[model.treeNodeSpec.input.name]"
                  @change="$_treeViewNode_onRadioChange" />
 
           {{ model[labelPropName] }}
@@ -98,7 +98,7 @@
             :model="model"
             :customClasses="customClasses">
 
-        <span :title="model.title"
+        <span :title="model.treeNodeSpec.title"
               class="tree-view-node-self-text"
               :class="customClasses.treeViewNodeSelfText">
           {{ model[labelPropName] }}
@@ -108,10 +108,10 @@
       <!-- Add Child button -->
       <button :id="addChildId"
               type="button"
-              v-if="model.addChildCallback"
+              v-if="model.treeNodeSpec.addChildCallback"
               aria-hidden="true"
               tabindex="-1"
-              :title="model.addChildTitle"
+              :title="model.treeNodeSpec.addChildTitle"
               class="tree-view-node-self-action"
               :class="[customClasses.treeViewNodeSelfAction, customClasses.treeViewNodeSelfAddChild]"
               @click="$_treeViewNode_onAddChild">
@@ -122,10 +122,10 @@
       <!-- Delete button -->
       <button :id="deleteId"
               type="button"
-              v-if="model.deletable"
+              v-if="model.treeNodeSpec.deletable"
               aria-hidden="true"
               tabindex="-1"
-              :title="model.deleteTitle"
+              :title="model.treeNodeSpec.deleteTitle"
               class="tree-view-node-self-action"
               :class="[customClasses.treeViewNodeSelfAction, customClasses.treeViewNodeSelfDelete]"
               @click="$_treeViewNode_onDelete">
@@ -135,19 +135,16 @@
     </div>
 
     <!-- Children -->
-    <ul v-show="model.state.expanded"
+    <ul v-show="model.treeNodeSpec.state.expanded"
         v-if="canExpand"
         class="tree-view-node-children"
         :class="customClasses.treeViewNodeChildren"
         role="group"
-        :aria-hidden="(!model.state.expanded).toString()">
+        :aria-hidden="(!model.treeNodeSpec.state.expanded).toString()">
       <TreeViewNode v-for="nodeModel in model[childrenPropName]"
-                      :key="nodeModel[$_treeViewNode_getIdPropNameForNode(nodeModel)]"
-                      :children-prop-names="childrenPropNames"
+                      :key="nodeModel[nodeModel.treeNodeSpec && nodeModel.treeNodeSpec.idProperty ? nodeModel.treeNodeSpec.idProperty : 'id']"
                       :depth="depth + 1"
-                      :id-prop-names="idPropNames"
                       :initial-model="nodeModel"
-                      :label-prop-names="labelPropNames"
                       :model-defaults="modelDefaults"
                       :parent-id="model[idPropName]"
                       :selection-mode="selectionMode"
@@ -191,24 +188,12 @@
       TreeViewNodeAria
     ],
     props: {
-      childrenPropNames: {
-        type: Array,
-        required: true
-      },
       depth: {
         type: Number,
         required: true
       },
-      idPropNames: {
-        type: Array,
-        required: true
-      },
       initialModel: {
         type: Object,
-        required: true
-      },
-      labelPropNames: {
-        type: Array,
         required: true
       },
       modelDefaults: {
@@ -244,12 +229,12 @@
         return this.nodeId ? `${this.nodeId}-add-child` : null;
       },
       ariaExpanded() {
-        return this.canExpand ? this.model.state.expanded.toString() : false;
+        return this.canExpand ? this.model.treeNodeSpec.state.expanded.toString() : false;
       },
       ariaSelected() {
         // If selection isn't allowed, don't add an aria-selected attribute.
         // If the tree contains nodes that are not selectable, those nodes do not have the aria-selected state.
-        if (this.selectionMode === null || !this.model.selectable) {
+        if (this.selectionMode === null || !this.model.treeNodeSpec.selectable) {
           return false;
         }
 
@@ -257,22 +242,22 @@
         // If the tree does not support multiple selection, aria-selected is set to true
         // for the selected node and it is not present on any other node in the tree.
         if (this.selectionMode !== 'multiple') {
-          return this.model.state.selected ? 'true' : false;
+          return this.model.treeNodeSpec.state.selected ? 'true' : false;
         }
 
         // If the tree supports multiple selection:
         //   All selected nodes have aria-selected set to true.
         //   All nodes that are selectable but not selected have aria-selected set to false.
-        return this.model.state.selected.toString();
+        return this.model.treeNodeSpec.state.selected.toString();
       },
       canExpand() {
-        return this.model[this.childrenPropName].length > 0 && this.model.expandable;
+        return this.model[this.childrenPropName].length > 0 && this.model.treeNodeSpec.expandable;
       },
       childrenPropName() {
-        return this.childrenPropNames.find(pn => Array.isArray(this.model[pn])) || 'children';
+        return this.model.treeNodeSpec.childrenProperty || 'children';
       },
       customClasses() {
-        return (this.model.customizations || {}).classes || {};
+        return (this.model.treeNodeSpec.customizations || {}).classes || {};
       },
       deleteId() {
         return this.nodeId ? `${this.nodeId}-delete` : null;
@@ -281,45 +266,40 @@
         return this.nodeId ? `${this.nodeId}-exp` : null;
       },
       idPropName() {
-        return this.$_treeViewNode_getIdPropNameForNode(this.model);
+        return this.model.treeNodeSpec.idProperty || 'id';
       },
       inputId() {
         return this.nodeId ? `${this.nodeId}-input` : null;
       },
       isEffectivelySelected() {
-        return this.selectionMode !== null && this.model.selectable && this.model.state.selected;
+        return this.selectionMode !== null && this.model.treeNodeSpec.selectable && this.model.treeNodeSpec.state.selected;
       },
       labelPropName() {
-        return this.labelPropNames.find(pn => typeof this.model[pn] === 'string')
+        return this.model.treeNodeSpec.labelProperty || 'label';
       },
       nodeId() {
         return this.treeId ? `${this.treeId}-${this.model[this.idPropName]}` : null;
       }
     },
     created() {
-      // id and label are required; notify the user. Validation is done here instead
-      // of at the prop level due to dependency on multiple props at once.
-      if (!this.idPropName) {
-        console.error(`initialModel id is required and must be a number or string. Allowed ID props: ${this.idPropNames.join(", ")}`);
-      }
-      else if(!this.labelPropName) {
-        console.error(`initialModel label is required and must be a string. Allowed label props: ${this.labelPropNames.join(", ")}`);
-      }
-
       this.$_treeViewNode_normalizeNodeData();
+
+      // id and label are required; notify the user. Validation is done here instead
+      // of at the prop level due to dependency on multiple props at once and defaulting
+      // that takes place in the normalization process
+      if (!this.model[this.idPropName] || (typeof this.model[this.idPropName] !== 'number' && typeof this.model[this.idPropName] !== 'string')) {
+        console.error(`initialModel id is required and must be a number or string. Expected prop ${this.idPropName} to exist on the model.`);
+      }
+      if(!this.model[this.labelPropName] || typeof this.model[this.labelPropName] !== 'string') {
+        console.error(`initialModel label is required and must be a string. Expected prop ${this.labelPropName} to exist on the model.`);
+      }
     },
     watch: {
-      'model.state.selected': function(newValue) {
+      'model.treeNodeSpec.state.selected': function(newValue) {
           this.$emit('treeViewNodeSelectedChange', this.model);
       }
     },
     methods: {
-      $_treeViewNode_getIdPropNameForNode(node) {
-        return this.idPropNames.find(pn => typeof node[pn] === 'number' || typeof node[pn] === 'string');
-      },
-      $_treeViewNode_getChildrenPropNameForNode(node) {
-        return this.childrenPropNames.find(pn => Array.isArray(node[pn])) || 'children';
-      },
       /*
        * Normalizes the data model to the format consumable by TreeViewNode.
        */
@@ -328,38 +308,48 @@
         this.$_treeViewNode_assignDefaultProps(this.modelDefaults, this.model);
 
         // Set expected properties if not provided
+        if (typeof this.model.treeNodeSpec.childrenProperty !== 'string') {
+          this.$set(this.model.treeNodeSpec, 'childrenProperty', 'children');
+        }
+        if (typeof this.model.treeNodeSpec.idProperty !== 'string') {
+          this.$set(this.model.treeNodeSpec, 'idProperty', 'id');
+        }
+        if (typeof this.model.treeNodeSpec.labelProperty !== 'string') {
+          this.$set(this.model.treeNodeSpec, 'labelProperty', 'label');
+        }
+
         if (!Array.isArray(this.model[this.childrenPropName])) {
           this.$set(this.model, this.childrenPropName, []);
         }
-        if (typeof this.model.expandable !== 'boolean') {
-          this.$set(this.model, 'expandable', true);
+        if (typeof this.model.treeNodeSpec.expandable !== 'boolean') {
+          this.$set(this.model.treeNodeSpec, 'expandable', true);
         }
-        if (typeof this.model.selectable !== 'boolean') {
-          this.$set(this.model, 'selectable', false);
+        if (typeof this.model.treeNodeSpec.selectable !== 'boolean') {
+          this.$set(this.model.treeNodeSpec, 'selectable', false);
         }
-        if (typeof this.model.deletable !== 'boolean') {
-          this.$set(this.model, 'deletable', false);
-        }
-
-        if (typeof this.model.addChildCallback !== 'function') {
-          this.$set(this.model, 'addChildCallback', null);
+        if (typeof this.model.treeNodeSpec.deletable !== 'boolean') {
+          this.$set(this.model.treeNodeSpec, 'deletable', false);
         }
 
-        if (typeof this.model.title !== 'string' || this.model.title.trim().length === 0) {
-          this.$set(this.model, 'title', null);
-        }
-        if (typeof this.model.expanderTitle !== 'string' || this.model.expanderTitle.trim().length === 0) {
-          this.$set(this.model, 'expanderTitle', null);
-        }
-        if (typeof this.model.addChildTitle !== 'string' || this.model.addChildTitle.trim().length === 0) {
-          this.$set(this.model, 'addChildTitle', null);
-        }
-        if (typeof this.model.deleteTitle !== 'string' || this.model.deleteTitle.trim().length === 0) {
-          this.$set(this.model, 'deleteTitle', null);
+        if (typeof this.model.treeNodeSpec.addChildCallback !== 'function') {
+          this.$set(this.model.treeNodeSpec, 'addChildCallback', null);
         }
 
-        if (this.model.customizations == null || typeof this.model.customizations !== 'object') {
-          this.$set(this.model, 'customizations', {});
+        if (typeof this.model.treeNodeSpec.title !== 'string' || this.model.treeNodeSpec.title.trim().length === 0) {
+          this.$set(this.model.treeNodeSpec, 'title', null);
+        }
+        if (typeof this.model.treeNodeSpec.expanderTitle !== 'string' || this.model.treeNodeSpec.expanderTitle.trim().length === 0) {
+          this.$set(this.model.treeNodeSpec, 'expanderTitle', null);
+        }
+        if (typeof this.model.treeNodeSpec.addChildTitle !== 'string' || this.model.treeNodeSpec.addChildTitle.trim().length === 0) {
+          this.$set(this.model.treeNodeSpec, 'addChildTitle', null);
+        }
+        if (typeof this.model.treeNodeSpec.deleteTitle !== 'string' || this.model.treeNodeSpec.deleteTitle.trim().length === 0) {
+          this.$set(this.model.treeNodeSpec, 'deleteTitle', null);
+        }
+
+        if (this.model.treeNodeSpec.customizations == null || typeof this.model.treeNodeSpec.customizations !== 'object') {
+          this.$set(this.model.treeNodeSpec, 'customizations', {});
         }
 
         this.$_treeViewNode_normalizeNodeInputData();
@@ -370,12 +360,12 @@
        */
       $_treeViewNode_normalizeNodeInputData() {
 
-        let input = this.model.input;
+        let input = this.model.treeNodeSpec.input;
 
         // For nodes that are inputs, they must specify at least a type.
         // Only a subset of types are accepted.
         if (input === null || typeof input !== 'object' || !['checkbox', 'radio'].includes(input.type)) {
-          this.$set(this.model, 'input', null);
+          this.$set(this.model.treeNodeSpec, 'input', null);
         }
         else {
           if (typeof input.name !== 'string' || input.name.trim().length === 0) {
@@ -399,11 +389,11 @@
        * Normalizes the data model's data related to the node's state.
        */
       $_treeViewNode_normalizeNodeStateData() {
-        if (this.model.state === null || typeof this.model.state !== 'object') {
-          this.$set(this.model, 'state', {});
+        if (this.model.treeNodeSpec.state === null || typeof this.model.treeNodeSpec.state !== 'object') {
+          this.$set(this.model.treeNodeSpec, 'state', {});
         }
 
-        let state = this.model.state;
+        let state = this.model.treeNodeSpec.state;
 
         if (typeof state.expanded !== 'boolean') {
           this.$set(state, 'expanded', false);
@@ -412,7 +402,7 @@
           this.$set(state, 'selected', false);
         }
 
-        if (this.model.input) {
+        if (this.model.treeNodeSpec.input) {
           if (state.input === null || typeof state.input !== 'object') {
             this.$set(state, 'input', {});
           }
@@ -421,7 +411,7 @@
             this.$set(state.input, 'disabled', false);
           }
 
-          if (this.model.input.type === 'checkbox') {
+          if (this.model.treeNodeSpec.input.type === 'checkbox') {
 
             if (typeof state.input.value !== 'boolean') {
               this.$set(state.input, 'value', false);
@@ -431,15 +421,20 @@
       },
       $_treeViewNode_assignDefaultProps(source, target) {
 
-        // Make sure they're objects
-        if (this.$_treeViewNode_isProbablyObject(source) && this.$_treeViewNode_isProbablyObject(target)) {
+        // The target model must have a treeNodeSpec property to assign defaults into
+        if (!this.$_treeViewNode_isProbablyObject(target.treeNodeSpec)) {
+          this.$set(target, 'treeNodeSpec', {});
+        }
+
+        // Make sure the defaults is an object
+        if (this.$_treeViewNode_isProbablyObject(source)) {
 
           // Use a copy of the source, since the props can be fubar'd by the assigns
           const sourceCopy = JSON.parse(JSON.stringify(source));
 
           // Assign defaults into the model
-          Object.assign(sourceCopy, target);
-          Object.assign(target, sourceCopy);
+          Object.assign(sourceCopy, target.treeNodeSpec);
+          Object.assign(target.treeNodeSpec, sourceCopy);
 
           // Find object properties to deep assign them
           // and find function properties and assign if missing in target
@@ -447,10 +442,10 @@
             const propValue = source[propName];
 
             if (this.$_treeViewNode_isProbablyObject(propValue)) {
-              this.$_treeViewNode_assignDefaultProps(propValue, target[propName]);
+              this.$_treeViewNode_assignDefaultProps(propValue, target.treeNodeSpec[propName]);
             }
-            else if (typeof propValue === 'function' && !target[propName]) {
-              target[propName] = propValue;
+            else if (typeof propValue === 'function' && !target.treeNodeSpec[propName]) {
+              target.treeNodeSpec[propName] = propValue;
             }
           }
         }
@@ -462,14 +457,14 @@
         this.$emit('treeViewNodeRadioChange', this.model, event);
       },
       $_treeViewNode_onExpandedChange(event) {
-        this.model.state.expanded = !this.model.state.expanded;
+        this.model.treeNodeSpec.state.expanded = !this.model.treeNodeSpec.state.expanded;
         this.$emit('treeViewNodeExpandedChange', this.model, event);
       },
       $_treeViewNode_toggleSelected(event) {
         // Note that selection change is already handled by the "model.focusable" watcher
         // method in TreeViewNodeAria if selectionMode is selectionFollowsFocus.
-        if (this.model.selectable && ['single', 'multiple'].includes(this.selectionMode)) {
-          this.model.state.selected = !this.model.state.selected;
+        if (this.model.treeNodeSpec.selectable && ['single', 'multiple'].includes(this.selectionMode)) {
+          this.model.treeNodeSpec.state.selected = !this.model.treeNodeSpec.state.selected;
         }
       },
       $_treeViewNode_onClick(event) {
@@ -492,8 +487,8 @@
        * supplied by an async callback which is the addChildCallback parameter of this node's model.
        */
       async $_treeViewNode_onAddChild(event) {
-        if (this.model.addChildCallback) {
-          var childModel = await this.model.addChildCallback(this.model);
+        if (this.model.treeNodeSpec.addChildCallback) {
+          var childModel = await this.model.treeNodeSpec.addChildCallback(this.model);
 
           if (childModel) {
             this.model[this.childrenPropName].push(childModel);
@@ -502,7 +497,7 @@
         }
       },
       $_treeViewNode_onDelete(event) {
-        if (this.model.deletable) {
+        if (this.model.treeNodeSpec.deletable) {
           this.$emit('treeViewNodeDelete', this.model, event);
         }
       },

--- a/src/mixins/TreeViewAria.js
+++ b/src/mixins/TreeViewAria.js
@@ -46,28 +46,28 @@ export default {
       // If one is found, set any subsequent to false.
       let firstSelectedNode = null;
       this.$_treeView_depthFirstTraverse((node) => {
-        if (node.focusable) {
+        if (node.treeNodeSpec.focusable) {
           if (this.focusableNodeModel) {
-            node.focusable = false;
+            node.treeNodeSpec.focusable = false;
           }
           else {
             this.$set(this, 'focusableNodeModel', node);
           }
         }
-        if (this.selectionMode !== null && firstSelectedNode === null && node.state.selected) {
+        if (this.selectionMode !== null && firstSelectedNode === null && node.treeNodeSpec.state.selected) {
           firstSelectedNode = node;
         }
       });
 
       if (!this.focusableNodeModel) {
         this.$set(this, 'focusableNodeModel', firstSelectedNode || this.model[0]);
-        this.$set(this.focusableNodeModel, 'focusable', true);
+        this.$set(this.focusableNodeModel.treeNodeSpec, 'focusable', true);
       }
 
       // Also default the selection to the focused node if no selected node was found
       // and the selection mode is selectionFollowsFocus.
-      if (firstSelectedNode === null && this.focusableNodeModel.selectable && this.selectionMode === 'selectionFollowsFocus') {
-        this.focusableNodeModel.state.selected = true;
+      if (firstSelectedNode === null && this.focusableNodeModel.treeNodeSpec.selectable && this.selectionMode === 'selectionFollowsFocus') {
+        this.focusableNodeModel.treeNodeSpec.state.selected = true;
       }
 
       this.$_treeViewNode_enforceSelectionMode();
@@ -87,41 +87,41 @@ export default {
       else if (this.selectionMode === 'selectionFollowsFocus') {
         // Make sure the actual focused item is selected if the mode changes, and deselect all others
         this.$_treeView_depthFirstTraverse((node) => {
-          let idPropName = this.$_treeView_getIdPropName(node);
-          let focusableIdPropName = this.$_treeView_getIdPropName(this.focusableNodeModel);
+          let idPropName = node.treeNodeSpec.idProperty;
+          let focusableIdPropName = this.focusableNodeModel.treeNodeSpec.idProperty;
           if (node[idPropName] === this.focusableNodeModel[focusableIdPropName]) {
-            if (node.selectable) {
-              node.state.selected = true;
+            if (node.treeNodeSpec.selectable) {
+              node.treeNodeSpec.state.selected = true;
             }
           }
-          else if (node.state.selected) {
-            node.state.selected = false;
+          else if (node.treeNodeSpec.state.selected) {
+            node.treeNodeSpec.state.selected = false;
           }
         });
       }
     },
     $_treeViewAria_handleFocusableChange(newNodeModel) {
       if (this.focusableNodeModel) {
-        this.focusableNodeModel.focusable = false;
+        this.focusableNodeModel.treeNodeSpec.focusable = false;
       }
 
       this.$set(this, 'focusableNodeModel', newNodeModel);
     },
     $_treeViewAria_focusFirstNode() {
-      this.model[0].focusable = true;
+      this.model[0].treeNodeSpec.focusable = true;
     },
     $_treeViewAria_focusLastNode() {
       let lastModel = this.model[this.model.length - 1];
-      let lastModelChildren = lastModel[this.$_treeView_getChildrenPropName(lastModel)];
-      while (lastModelChildren.length > 0 && lastModel.expandable && lastModel.state.expanded) {
+      let lastModelChildren = lastModel[lastModel.treeNodeSpec.childrenProperty];
+      while (lastModelChildren.length > 0 && lastModel.treeNodeSpec.expandable && lastModel.treeNodeSpec.state.expanded) {
         lastModel = lastModelChildren[lastModelChildren.length - 1];
-        lastModelChildren = lastModel[this.$_treeView_getChildrenPropName(lastModel)];
+        lastModelChildren = lastModel[lastModel.treeNodeSpec.childrenProperty];
       }
 
-      lastModel.focusable = true;
+      lastModel.treeNodeSpec.focusable = true;
     },
     $_treeViewAria_handleNodeDeletion(node) {
-      if (node.focusable) {
+      if (node.treeNodeSpec.focusable) {
         if (this.model.indexOf(node) === 0) {
           if (this.model.length > 0) {
             this.$_treeViewAria_handleNextFocus(node);
@@ -138,13 +138,13 @@ export default {
       let childIndex = this.model.indexOf(childNode);
       if (childIndex > 0) {
         let lastModel = this.model[childIndex - 1];
-        let lastModelChildren = lastModel[this.$_treeView_getChildrenPropName(lastModel)];
-        while (lastModelChildren.length > 0 && lastModel.expandable && lastModel.state.expanded) {
+        let lastModelChildren = lastModel[lastModel.treeNodeSpec.childrenProperty];
+        while (lastModelChildren.length > 0 && lastModel.treeNodeSpec.expandable && lastModel.treeNodeSpec.state.expanded) {
           lastModel = lastModelChildren[lastModelChildren.length - 1];
-          lastModelChildren = lastModel[this.$_treeView_getChildrenPropName(lastModel)];
+          lastModelChildren = lastModel[lastModel.treeNodeSpec.childrenProperty];
         }
 
-        lastModel.focusable = true;
+        lastModel.treeNodeSpec.focusable = true;
       }
     },
     $_treeViewAria_handleNextFocus(childNode, ignoreChild) {
@@ -152,13 +152,13 @@ export default {
       // If the node has a next sibling, focus that
       // Otherwise, do nothing
       let childIndex = this.model.indexOf(childNode);
-      let childNodeChildren = childNode[this.$_treeView_getChildrenPropName(childNode)];
+      let childNodeChildren = childNode[childNode.treeNodeSpec.childrenProperty];
 
-      if (!ignoreChild && childNodeChildren.length > 0 && childNode.expandable && childNode.state.expanded) {
-        childNodeChildren[0].focusable = true;
+      if (!ignoreChild && childNodeChildren.length > 0 && childNode.treeNodeSpec.expandable && childNode.treeNodeSpec.state.expanded) {
+        childNodeChildren[0].treeNodeSpec.focusable = true;
       }
       else if (childIndex < this.model.length - 1) {
-        this.model[childIndex + 1].focusable = true;
+        this.model[childIndex + 1].treeNodeSpec.focusable = true;
       }
     }
   }

--- a/tests/data/node-generator.js
+++ b/tests/data/node-generator.js
@@ -8,8 +8,8 @@
  *  `[eE]?[sS]?[d]?[f]?[[cCrR]!?]?`
  *
  * This identifies if the node is:
- *  e: expandable. If capitalized, state.expanded is set to true.
- *  s: selectable. If capitalized, state.selected is set to true.
+ *  e: expandable. If capitalized, .treeNodeSpec.state.expanded is set to true.
+ *  s: selectable. If capitalized, .treeNodeSpec.state.selected is set to true.
  *  d: deletable
  *  f: focusable
  *  c: is a checkbox node. If capitalized, it's checked. If followed by '!', it's disabled. Cannot be used with 'r'.
@@ -41,46 +41,51 @@ export function generateNodes(nodeSpec, radioState, baseId = "", addChildCallbac
             prevNode = {
                 id: idString,
                 label: 'Node ' + index,
-                expandable: lowerItem.includes('e'),
-                selectable: lowerItem.includes('s'),
-                deletable: lowerItem.includes('d'),
-                focusable: lowerItem.includes('f'),
-                input: lowerItem.includes('c')
-                    ? { type: 'checkbox', name: `${idString}-cbx` }
-                    : lowerItem.includes('r')
-                        ? { type: 'radio', name: `${baseId || 'root'}-rb`, value: `${idString}-val` }
-                        : null,
-                state: {
-                    expanded: item.includes('E'),
-                    selected: item.includes('S')
-                },
-                addChildCallback,
-                children: []
+                children: [],
+                treeNodeSpec: {
+                    childrenProperty: 'children',
+                    idProperty: 'id',
+                    labelProperty: 'label',
+                    expandable: lowerItem.includes('e'),
+                    selectable: lowerItem.includes('s'),
+                    deletable: lowerItem.includes('d'),
+                    focusable: lowerItem.includes('f'),
+                    input: lowerItem.includes('c')
+                        ? { type: 'checkbox', name: `${idString}-cbx` }
+                        : lowerItem.includes('r')
+                            ? { type: 'radio', name: `${baseId || 'root'}-rb`, value: `${idString}-val` }
+                            : null,
+                    state: {
+                        expanded: item.includes('E'),
+                        selected: item.includes('S')
+                    },
+                    addChildCallback
+                }
             };
 
             // Set up input state if needed
-            if (prevNode.input) {
+            if (prevNode.treeNodeSpec.input) {
 
                 // Disable inputs
-                prevNode.state.input = {
+                prevNode.treeNodeSpec.state.input = {
                     disabled: item.includes('!')
                 };
 
                 // Set up checkbox state
                 if (lowerItem.includes('c')) {
-                    prevNode.state.input.value = item.includes('C')
+                    prevNode.treeNodeSpec.state.input.value = item.includes('C')
                 }
 
                 // Set up the radiobutton state in the radioState
                 if (lowerItem.includes('r')) {
-                    if (!radioState.hasOwnProperty(prevNode.input.name)) {
-                        radioState[prevNode.input.name] = null;
+                    if (!radioState.hasOwnProperty(prevNode.treeNodeSpec.input.name)) {
+                        radioState[prevNode.treeNodeSpec.input.name] = null;
                     }
 
                     // Radio button selectedness can also be specified in the normal way by providing
                     // the radio button data to the TreeView's radioGroupValues prop.
                     if (item.includes('R')) {
-                        radioState[prevNode.input.name] = prevNode.input.value;
+                        radioState[prevNode.treeNodeSpec.input.name] = prevNode.treeNodeSpec.input.value;
                     }
                 }
             }

--- a/tests/local/basic.js
+++ b/tests/local/basic.js
@@ -2,72 +2,47 @@ export default [
   {
     id: 'node1',
     label: 'My First Node',
-    expandable: true,
-    selectable: true,
-    deletable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox1'
-    },
-    state: {
-      expanded: false,
-      selected: false,
+    children: [],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      deletable: true,
       input: {
-        value: false,
-        disabled: false
+        type: 'checkbox',
+        name: 'checkbox1'
+      },
+      state: {
+        expanded: false,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
       }
-    },
-    children: []
+    }
   },
   {
     id: 'node2',
     label: 'My Second Node',
-    title: 'My second node, and its fantastic title',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox2'
-    },
-    state: {
-      expanded: true,
-      selected: false,
-      input: {
-        value: false,
-        disabled: false
-      }
-    },
     children: [
       {
         id: 'subnode1',
         label: 'This is a subnode',
-        title: 'Even non-input nodes should get a title.',
-        expandable: true,
-        selectable: true,
-        deletable: true,
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          title: 'Even non-input nodes should get a title.',
+          expandable: true,
+          selectable: true,
+          deletable: true,
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       },
       {
         id: 'subnode2',
         label: 'This is a checkable, checked subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'checkbox',
-          name: 'checkbox3'
-        },
-        state: {
-          expanded: false,
-          selected: false,
-          input: {
-            value: true,
-            disabled: true
-          }
-        },
         children: [
           {
             id: 'subsubnode1',
@@ -84,8 +59,41 @@ export default [
               return Promise.resolve(entry ? { id: entry, label: entry, deletable: true, selectable: true } : null);
             }
           }
-        ]
+        ],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'checkbox',
+            name: 'checkbox3'
+          },
+          state: {
+            expanded: false,
+            selected: false,
+            input: {
+              value: true,
+              disabled: true
+            }
+          }
+        }
       }
-    ]
+    ],
+    treeNodeSpec: {
+      title: 'My second node, and its fantastic title',
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'checkbox',
+        name: 'checkbox2'
+      },
+      state: {
+        expanded: true,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
+      }
+    }
   }
 ];

--- a/tests/local/radioBasic.js
+++ b/tests/local/radioBasic.js
@@ -2,63 +2,71 @@ export default [
   {
     id: 'node1',
     label: 'My First Node',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'radio',
-      name: 'radio1',
-      value: 'aValueToSubmit'
-    },
-    state: {
-      expanded: false,
-      selected: false
-    },
-    children: []
+    children: [],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'radio',
+        name: 'radio1',
+        value: 'aValueToSubmit'
+      },
+      state: {
+        expanded: false,
+        selected: false
+      }
+    }
   },
   {
     id: 'node2',
     label: 'My Second Node',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'radio',
-      name: 'radio1'
-    },
-    state: {
-      expanded: true,
-      selected: false
-    },
     children: [
       {
         id: 'subnode1',
         label: 'This is a subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'radio',
-          name: 'radio2'
-        },
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'radio',
+            name: 'radio2'
+          },
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       },
       {
         id: 'subnode2',
         label: 'This is a checkable, checked subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'radio',
-          name: 'radio2'
-        },
-        state: {
-          expanded: false,
-          selected: false
-        },
-        children: []
+        children: [],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'radio',
+            name: 'radio2'
+          },
+          state: {
+            expanded: false,
+            selected: false
+          }
+        }
       }
-    ]
+    ],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'radio',
+        name: 'radio1'
+      },
+      state: {
+        expanded: true,
+        selected: false
+      }
+    }
   }
 ];

--- a/tests/local/selection.js
+++ b/tests/local/selection.js
@@ -2,41 +2,28 @@ export default [
   {
     id: 'node1',
     label: 'My First Node',
-    expandable: true,
-    selectable: true,
-    deletable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox1'
-    },
-    state: {
-      expanded: false,
-      selected: false,
+    children: [],
+    treeNodeSpec: {
+      expandable: true,
+      selectable: true,
+      deletable: true,
       input: {
-        value: false,
-        disabled: false
+        type: 'checkbox',
+        name: 'checkbox1'
+      },
+      state: {
+        expanded: false,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
       }
-    },
-    children: []
+    }
   },
   {
     id: 'node2',
     label: 'My Second Node',
-    title: 'My second node, and its fantastic title',
-    expandable: true,
-    selectable: true,
-    input: {
-      type: 'checkbox',
-      name: 'checkbox2'
-    },
-    state: {
-      expanded: true,
-      selected: false,
-      input: {
-        value: false,
-        disabled: false
-      }
-    },
     children: [
       {
         id: 'subnode1',
@@ -54,20 +41,6 @@ export default [
       {
         id: 'subnode2',
         label: 'This is a checkable, checked subnode',
-        expandable: true,
-        selectable: true,
-        input: {
-          type: 'checkbox',
-          name: 'checkbox3'
-        },
-        state: {
-          expanded: false,
-          selected: false,
-          input: {
-            value: true,
-            disabled: true
-          }
-        },
         children: [
           {
             id: 'subsubnode1',
@@ -84,8 +57,41 @@ export default [
               return Promise.resolve(entry ? { id: entry, label: entry, deletable: true, selectable: true } : null);
             }
           }
-        ]
+        ],
+        treeNodeSpec: {
+          expandable: true,
+          selectable: true,
+          input: {
+            type: 'checkbox',
+            name: 'checkbox3'
+          },
+          state: {
+            expanded: false,
+            selected: false,
+            input: {
+              value: true,
+              disabled: true
+            }
+          }
+        }
       }
-    ]
+    ],
+    treeNodeSpec: {
+      title: 'My second node, and its fantastic title',
+      expandable: true,
+      selectable: true,
+      input: {
+        type: 'checkbox',
+        name: 'checkbox2'
+      },
+      state: {
+        expanded: true,
+        selected: false,
+        input: {
+          value: false,
+          disabled: false
+        }
+      }
+    }
   }
 ];

--- a/tests/local/slots.html
+++ b/tests/local/slots.html
@@ -16,33 +16,33 @@
           <tree id="customtree" :initial-model="model">
 
             <template #text="{ model, customClasses }">
-              <span>{{ model.label }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
+              <span>{{ model[model.treeNodeSpec.labelProperty] }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
             </template>
 
             <template #checkbox="{ model, customClasses, inputId, checkboxChangeHandler }">
-              <label :for="inputId" :title="model.title">
+              <label :for="inputId" :title="model.treeNodeSpec.title">
 
                 <input :id="inputId"
                        type="checkbox"
-                       :disabled="model.state.input.disabled" v-model="model.state.input.value"
+                       :disabled="model.treeNodeSpec.state.input.disabled" v-model="model.treeNodeSpec.state.input.value"
                        @change="checkboxChangeHandler" />
 
-                <marquee style="max-width: 6rem">{{ model.label }}. Custom Classes: {{ JSON.stringify(customClasses) }}</marquee>
+                <marquee style="max-width: 6rem">{{ model[model.treeNodeSpec.labelProperty] }}. Custom Classes: {{ JSON.stringify(customClasses) }}</marquee>
               </label>
             </template>
 
             <template #radio="{ model, customClasses, inputId, inputModel, radioChangeHandler }">
-              <label :for="inputId" :title="model.title">
+              <label :for="inputId" :title="model.treeNodeSpec.title">
 
                 <input :id="inputId"
                        type="radio"
-                       :name="model.input.name"
-                       :value="model.input.value"
-                       :disabled="model.state.input.disabled"
+                       :name="model.treeNodeSpec.input.name"
+                       :value="model.treeNodeSpec.input.value"
+                       :disabled="model.treeNodeSpec.state.input.disabled"
                        v-model="inputModel"
                        @change="radioChangeHandler" />
 
-                <span style="font-weight: bolder">{{ model.label }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
+                <span style="font-weight: bolder">{{ model[model.treeNodeSpec.labelProperty] }}. Custom Classes: {{ JSON.stringify(customClasses) }}</span>
               </label>
             </template>
 

--- a/tests/local/slots.js
+++ b/tests/local/slots.js
@@ -2,17 +2,19 @@ export default [
   {
     id: 'node1',
     label: 'Checkbox Node',
-    input: {
-      type: 'checkbox',
-      name: 'checkbox1'
-    },
-    state: {
+    children: [],
+    treeNodeSpec: {
       input: {
-        value: false,
-        disabled: false
+        type: 'checkbox',
+        name: 'checkbox1'
+      },
+      state: {
+        input: {
+          value: false,
+          disabled: false
+        }
       }
-    },
-    children: []
+    }
   },
   {
     id: 'node2',

--- a/tests/unit/TreeView.eventHandling.spec.js
+++ b/tests/unit/TreeView.eventHandling.spec.js
@@ -112,7 +112,7 @@ describe('TreeView.vue (event handling)', () => {
         });
 
         it('deselects other selected nodes', () => {
-          expect(wrapper.vm.model[1].state.selected).to.be.false;
+          expect(wrapper.vm.model[1].treeNodeSpec.state.selected).to.be.false;
         });
       });
 
@@ -124,7 +124,7 @@ describe('TreeView.vue (event handling)', () => {
         });
 
         it('does not deselect other selected nodes', () => {
-          expect(wrapper.vm.model[1].state.selected).to.be.true;
+          expect(wrapper.vm.model[1].treeNodeSpec.state.selected).to.be.true;
         });
       });
     });

--- a/tests/unit/TreeView.spec.js
+++ b/tests/unit/TreeView.spec.js
@@ -112,7 +112,12 @@ describe('TreeView.vue', () => {
     });
 
     it('should return nodes matched by the function argument', () => {
-      let nodes = wrapper.vm.getMatching((nodeModel) => nodeModel.expandable && nodeModel.state.expanded && nodeModel.selectable && nodeModel.state.selected);
+      let nodes = wrapper.vm.getMatching((nodeModel) =>
+        nodeModel.treeNodeSpec.expandable
+        && nodeModel.treeNodeSpec.state.expanded
+        && nodeModel.treeNodeSpec.selectable
+        && nodeModel.treeNodeSpec.state.selected);
+
       expect(nodes.length).to.equal(1);
     });
   });
@@ -156,8 +161,8 @@ describe('TreeView.vue', () => {
     });
 
     it('should only keep the selectable=true state for the first node with that in the initial model', () => {
-      expect(wrapper.vm.model[1].state.selected).to.be.true;
-      expect(wrapper.vm.model[1].children[1].state.selected).to.be.false;
+      expect(wrapper.vm.model[1].treeNodeSpec.state.selected).to.be.true;
+      expect(wrapper.vm.model[1].children[1].treeNodeSpec.state.selected).to.be.false;
     });
   });
 
@@ -180,39 +185,6 @@ describe('TreeView.vue', () => {
 
     it('should have an aria-multiselectable attribute of true', () => {
       expect(wrapper.vm.$el.attributes['aria-multiselectable'].value).to.equal('true');
-    });
-  });
-
-  describe('when idPropNames is not specified', () => {
-
-    beforeEach(() => {
-      wrapper = createWrapper();
-    });
-
-    it('has a default value of ["id"]', () => {
-      expect(wrapper.vm.idPropNames).to.eql(['id']);
-    });
-  });
-
-  describe('when labelPropNames is not specified', () => {
-
-    beforeEach(() => {
-      wrapper = createWrapper();
-    });
-
-    it('has a default value of ["label"]', () => {
-      expect(wrapper.vm.labelPropNames).to.eql(['label']);
-    });
-  });
-
-  describe('when childrenPropNames is not specified', () => {
-
-    beforeEach(() => {
-      wrapper = createWrapper();
-    });
-
-    it('has a default value of ["children"]', () => {
-      expect(wrapper.vm.childrenPropNames).to.eql(['children']);
     });
   });
 });

--- a/tests/unit/TreeViewAria.spec.js
+++ b/tests/unit/TreeViewAria.spec.js
@@ -101,7 +101,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('should set the first node as focusable', () => {
-        expect(wrapper.vm.model[0].focusable).to.be.true;
+        expect(wrapper.vm.model[0].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -112,7 +112,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('should set the first selected node as focusable', () => {
-        expect(wrapper.vm.model[1].children[0].focusable).to.be.true;
+        expect(wrapper.vm.model[1].children[0].treeNodeSpec.focusable).to.be.true;
       });
     });
   });
@@ -126,11 +126,11 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('should keep that node as focusable', () => {
-        expect(wrapper.vm.model[1].focusable).to.be.true;
+        expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
       });
 
       it('should set focusble to false for any further nodes', () => {
-        expect(wrapper.vm.model[1].children[0].focusable).to.be.false;
+        expect(wrapper.vm.model[1].children[0].treeNodeSpec.focusable).to.be.false;
       });
     });
 
@@ -143,7 +143,7 @@ describe('TreeView.vue (ARIA)', () => {
         });
 
         it('should select the focused node', () => {
-          expect(wrapper.vm.model[1].state.selected).to.be.true;
+          expect(wrapper.vm.model[1].treeNodeSpec.state.selected).to.be.true;
         });
       });
 
@@ -158,7 +158,7 @@ describe('TreeView.vue (ARIA)', () => {
     });
 
     it('should remove focusable from the previous focusable node', () => {
-      expect(wrapper.vm.model[0].focusable).to.be.false;
+      expect(wrapper.vm.model[0].treeNodeSpec.focusable).to.be.false;
     });
 
     it('should set the new node as the current focusable node', () => {
@@ -174,7 +174,7 @@ describe('TreeView.vue (ARIA)', () => {
     });
 
     it('should set the focusable attribute of the first node to true', () => {
-      expect(wrapper.vm.model[0].focusable).to.be.true;
+      expect(wrapper.vm.model[0].treeNodeSpec.focusable).to.be.true;
     });
   });
 
@@ -184,14 +184,14 @@ describe('TreeView.vue (ARIA)', () => {
       wrapper = createWrapper({ initialModel: generateNodes(['ecsf', 'eCs'], {}) });
       wrapper.vm.$_treeViewAria_focusLastNode();
 
-      expect(wrapper.vm.model[1].focusable).to.be.true;
+      expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
     });
 
     it('should ignore non-expanded child nodes', () => {
       wrapper = createWrapper({ initialModel: generateNodes(['ecsf', 'eCs', 'ecs', ['ecs']], {}) });
       wrapper.vm.$_treeViewAria_focusLastNode();
 
-      expect(wrapper.vm.model[2].focusable).to.be.true;
+      expect(wrapper.vm.model[2].treeNodeSpec.focusable).to.be.true;
     });
   });
 
@@ -205,7 +205,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('does not change the focusable node', () => {
-        expect(wrapper.vm.model[0].focusable).to.be.true;
+        expect(wrapper.vm.model[0].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -217,7 +217,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('sets the next node as focusable', () => {
-        expect(wrapper.vm.model[1].focusable).to.be.true;
+        expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -229,7 +229,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('sets the previous node as focusable', () => {
-        expect(wrapper.vm.model[1].focusable).to.be.true;
+        expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
       });
     })
   });
@@ -244,7 +244,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('does not change focusableness', () => {
-        expect(wrapper.vm.model[0].focusable).to.be.true;
+        expect(wrapper.vm.model[0].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -256,7 +256,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('sets the previous node as focusable', () => {
-        expect(wrapper.vm.model[0].focusable).to.be.true;
+        expect(wrapper.vm.model[0].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -268,7 +268,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('sets the last expanded previous node as focusable', () => {
-        expect(wrapper.vm.model[0].children[1].focusable).to.be.true;
+        expect(wrapper.vm.model[0].children[1].treeNodeSpec.focusable).to.be.true;
       });
     });
   });
@@ -283,7 +283,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('does not change focusableness', () => {
-        expect(wrapper.vm.model[1].focusable).to.be.true;
+        expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -295,7 +295,7 @@ describe('TreeView.vue (ARIA)', () => {
       });
 
       it('sets the next sibling node as focusable', () => {
-        expect(wrapper.vm.model[1].focusable).to.be.true;
+        expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -307,14 +307,14 @@ describe('TreeView.vue (ARIA)', () => {
 
       it('sets the first expanded child node as focusable', () => {
         wrapper.vm.$_treeViewAria_handleNextFocus(wrapper.vm.model[0]);
-        expect(wrapper.vm.model[0].children[0].focusable).to.be.true;
+        expect(wrapper.vm.model[0].children[0].treeNodeSpec.focusable).to.be.true;
       });
 
       describe('and the children are explicitly ignored', () => {
 
         if ('sets the next sibling node as focusable', () => {
           wrapper.vm.$_treeViewAria_handleNextFocus(wrapper.vm.model[0], true);
-          expect(wrapper.vm.model[1].focusable).to.be.true;
+          expect(wrapper.vm.model[1].treeNodeSpec.focusable).to.be.true;
         });
       });
     });
@@ -329,11 +329,11 @@ describe('TreeView.vue (ARIA)', () => {
     });
 
     it('should select the focused node', () => {
-      expect(wrapper.vm.model[0].state.selected).to.be.true;
+      expect(wrapper.vm.model[0].treeNodeSpec.state.selected).to.be.true;
     });
 
     it('should deselect the previously selected node', () => {
-      expect(wrapper.vm.model[0].children[0].state.selected).to.be.false;
+      expect(wrapper.vm.model[0].children[0].treeNodeSpec.state.selected).to.be.false;
     });
   });
 });

--- a/tests/unit/TreeViewNode.customizations.spec.js
+++ b/tests/unit/TreeViewNode.customizations.spec.js
@@ -20,10 +20,7 @@ const getDefaultPropsData = function () {
       insertItem: [45], // Insert
       deleteItem: [46] // Delete
     },
-    childrenPropNames: ['children'],
-    idPropNames: ['id'],
     initialModel: generateNodes(['ces'], radioState)[0],
-    labelPropNames: ['label'],
     modelDefaults: {},
     depth: 0,
     treeId: 'tree-id',
@@ -80,10 +77,7 @@ describe('TreeViewNode.vue (customizations)', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: { customizations },
         depth: 0,
         treeId: 'tree',
@@ -201,10 +195,7 @@ describe('TreeViewNode.vue (customizations)', () => {
         wrapper = createWrapper(
           {
             ariaKeyMap: {},
-            childrenPropNames: ['children'],
-            idPropNames: ['id'],
             initialModel,
-            labelPropNames: ['label'],
             modelDefaults: { customizations: { classes: customClasses } },
             depth: 0,
             treeId: 'tree',
@@ -240,10 +231,7 @@ describe('TreeViewNode.vue (customizations)', () => {
         wrapper = createWrapper(
           {
             ariaKeyMap: {},
-            childrenPropNames: ['children'],
-            idPropNames: ['id'],
             initialModel,
-            labelPropNames: ['label'],
             modelDefaults: { customizations: { classes: customClasses } },
             depth: 0,
             treeId: 'tree',
@@ -291,10 +279,7 @@ describe('TreeViewNode.vue (customizations)', () => {
         wrapper = createWrapper(
           {
             ariaKeyMap: {},
-            childrenPropNames: ['children'],
-            idPropNames: ['id'],
             initialModel,
-            labelPropNames: ['label'],
             modelDefaults: { customizations: { classes: customClasses } },
             depth: 0,
             treeId: 'tree',

--- a/tests/unit/TreeViewNode.interactions.spec.js
+++ b/tests/unit/TreeViewNode.interactions.spec.js
@@ -20,10 +20,7 @@ const getDefaultPropsData = function () {
       insertItem: [45], // Insert
       deleteItem: [46] // Delete
     },
-    childrenPropNames: ['children'],
-    idPropNames: ['id'],
     initialModel: generateNodes(['ces'], radioState)[0],
-    labelPropNames: ['label'],
     modelDefaults: {},
     depth: 0,
     treeId: 'tree-id',
@@ -76,7 +73,7 @@ describe('TreeViewNode.vue (interactions)', () => {
       });
 
       it('should toggle the selected state', () => {
-        expect(wrapper.vm.model.state.selected).to.be.true;
+        expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.true;
       });
     });
 
@@ -89,7 +86,7 @@ describe('TreeViewNode.vue (interactions)', () => {
       });
 
       it('should not toggle the selected state', () => {
-        expect(wrapper.vm.model.state.selected).to.be.false;
+        expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.false;
       });
     });
   });
@@ -117,10 +114,7 @@ describe('TreeViewNode.vue (interactions)', () => {
       let radioState = {};
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['ces', ['ces']], radioState)[0],
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -132,7 +126,7 @@ describe('TreeViewNode.vue (interactions)', () => {
 
     it('should toggle the expanded state', () => {
       expander.trigger('click');
-      expect(wrapper.vm.model.state.expanded).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.state.expanded).to.be.true;
     });
 
     it('should emit the treeViewNodeExpandedChange event', () => {
@@ -162,7 +156,7 @@ describe('TreeViewNode.vue (interactions)', () => {
 
     it('should toggle the input value state', () => {
       checkbox.setChecked();
-      expect(wrapper.vm.model.state.input.value).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.state.input.value).to.be.true;
     });
 
     it('should emit the treeViewNodeCheckboxChange event', () => {
@@ -190,10 +184,7 @@ describe('TreeViewNode.vue (interactions)', () => {
       radioState = {};
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['res'], radioState)[0],
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -206,7 +197,7 @@ describe('TreeViewNode.vue (interactions)', () => {
     it('should toggle the input value state', () => {
       radioButton.setChecked();
       let model = wrapper.vm.model;
-      expect(wrapper.vm.radioGroupValues[model.input.name]).to.equal(model.input.value);
+      expect(wrapper.vm.radioGroupValues[model.treeNodeSpec.input.name]).to.equal(model.treeNodeSpec.input.value);
     });
 
     it('should emit the treeViewNodeRadioChange event', () => {
@@ -234,10 +225,7 @@ describe('TreeViewNode.vue (interactions)', () => {
       let radioState = {};
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['es', ['ds']], radioState)[0],
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -272,10 +260,7 @@ describe('TreeViewNode.vue (interactions)', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel: generateNodes(['esa'], radioState, "", addChildCallback)[0],
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -312,10 +297,7 @@ describe('TreeViewNode.vue (interactions)', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel: generateNodes(['esa'], radioState, "", addChildCallback)[0],
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',

--- a/tests/unit/TreeViewNode.spec.js
+++ b/tests/unit/TreeViewNode.spec.js
@@ -9,10 +9,7 @@ const getDefaultPropsData = function () {
   let radioState = {};
   return {
     ariaKeyMap: {},
-    childrenPropNames: ['children'],
-    idPropNames: ['id'],
     initialModel: generateNodes(['ces'], radioState)[0],
-    labelPropNames: ['label'],
     modelDefaults: {},
     depth: 0,
     treeId: 'tree-id',
@@ -46,11 +43,8 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
         depth: 0,
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {},
         radioGroupValues: {}
       });
@@ -59,30 +53,27 @@ describe('TreeViewNode.vue', () => {
     it('normalizes model data', () => {
       expect(wrapper.vm.model.id).to.equal('my-node');
       expect(wrapper.vm.model.label).to.equal('My Node');
-      expect(wrapper.vm.model.title).to.be.null;
-      expect(wrapper.vm.model.expandable).to.be.true;
-      expect(wrapper.vm.model.selectable).to.be.false;
-      expect(wrapper.vm.model.deletable).to.be.false;
-      expect(wrapper.vm.model.state).to.exist;
-      expect(wrapper.vm.model.state.expanded).to.be.false;
-      expect(wrapper.vm.model.state.selected).to.be.false;
-      expect(wrapper.vm.model.input).to.be.null;
-      expect(wrapper.vm.model.state.input).to.not.exist;
+      expect(wrapper.vm.model.treeNodeSpec.title).to.be.null;
+      expect(wrapper.vm.model.treeNodeSpec.expandable).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.selectable).to.be.false;
+      expect(wrapper.vm.model.treeNodeSpec.deletable).to.be.false;
+      expect(wrapper.vm.model.treeNodeSpec.state).to.exist;
+      expect(wrapper.vm.model.treeNodeSpec.state.expanded).to.be.false;
+      expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.false;
+      expect(wrapper.vm.model.treeNodeSpec.input).to.be.null;
+      expect(wrapper.vm.model.treeNodeSpec.state.input).to.not.exist;
     });
   });
 
   describe('when given default model data', () => {
 
     beforeEach(() => {
-      let initialModel = { id: 'my-node', label: 'My Node', expandable: true };
+      let initialModel = { id: 'my-node', label: 'My Node', treeNodeSpec: { expandable: true } };
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
         depth: 0,
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {
           expandable: false,
           selectable: true,
@@ -96,12 +87,12 @@ describe('TreeViewNode.vue', () => {
     });
 
     it('should incorporate the default data into the model for unspecified properties', () => {
-      expect(wrapper.vm.model.selectable).to.be.true;
-      expect(wrapper.vm.model.state.selected).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.selectable).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.true;
     });
 
     it('should use the model\'s data over the default data for specified properties', () => {
-      expect(wrapper.vm.model.expandable).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.expandable).to.be.true;
     });
   });
 
@@ -110,11 +101,8 @@ describe('TreeViewNode.vue', () => {
     beforeEach(() => {
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
         depth: 0,
-        idPropNames: ['id'],
-        initialModel: { id: 'my-node', label: 'My Node', title: 'My Title' },
-        labelPropNames: ['label'],
+        initialModel: { id: 'my-node', label: 'My Node', treeNodeSpec: { title: 'My Title' } },
         modelDefaults: {},
         radioGroupValues: {}
       });
@@ -130,7 +118,7 @@ describe('TreeViewNode.vue', () => {
 
     beforeEach(() => {
       let data = getDefaultPropsData();
-      data.initialModel.title = "My Title";
+      data.initialModel.treeNodeSpec.title = "My Title";
 
       wrapper = createWrapper(data);
     });
@@ -169,10 +157,7 @@ describe('TreeViewNode.vue', () => {
       let radioState = {};
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['ces'], radioState)[0],
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         radioGroupValues: radioState
@@ -201,10 +186,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['es'], radioState)[0],
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -231,10 +213,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['esa'], radioState, "", addChildCallback)[0],
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -261,10 +240,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel: generateNodes(['esa'], radioState)[0],
-        labelPropNames: ['label'],
         modelDefaults: { addChildCallback },
         depth: 0,
         treeId: 'tree',
@@ -287,10 +263,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -327,10 +300,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -369,10 +339,7 @@ describe('TreeViewNode.vue', () => {
 
           wrapper = createWrapper({
             ariaKeyMap: {},
-            childrenPropNames: ['children'],
-            idPropNames: ['id'],
             initialModel,
-            labelPropNames: ['label'],
             modelDefaults: {},
             depth: 0,
             treeId: 'tree',
@@ -405,10 +372,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -432,10 +396,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -462,10 +423,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -488,10 +446,7 @@ describe('TreeViewNode.vue', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
@@ -516,10 +471,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -542,10 +494,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -571,10 +520,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -597,10 +543,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -626,10 +569,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -652,10 +592,7 @@ describe('TreeViewNode.vue', () => {
 
         wrapper = createWrapper({
           ariaKeyMap: {},
-          childrenPropNames: ['children'],
-          idPropNames: ['id'],
           initialModel,
-          labelPropNames: ['label'],
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
@@ -674,7 +611,7 @@ describe('TreeViewNode.vue', () => {
 
     beforeEach(async () => {
       wrapper = createWrapper();
-      wrapper.vm.model.state.selected = true;
+      wrapper.vm.model.treeNodeSpec.state.selected = true;
       await wrapper.vm.$nextTick();
     });
 
@@ -683,74 +620,57 @@ describe('TreeViewNode.vue', () => {
     });
   });
 
-  describe('when idPropNames is specified', () => {
+  describe('when idProperty is specified', () => {
 
-    beforeEach(() => {
-      wrapper = createWrapper(Object.assign(getDefaultPropsData(), {
-        idPropNames: ['nope', 'label']
-      }));
+    beforeEach(async () => {
+      wrapper = createWrapper();
+      wrapper.vm.model.treeNodeSpec.idProperty = 'label';
+      await wrapper.vm.$nextTick();
     });
 
-    it('has an idPropName matching the first-avilable valid-id model property', () => {
+    it('has an idPropName matching the idProperty', () => {
       expect(wrapper.vm.idPropName).to.equal('label');
     });
 
-    it('has a nodeId made of the tree ID and the first-avilable model[idPropName] property', () => {
+    it('has a nodeId made of the tree ID and the model[idPropName] property', () => {
       expect(wrapper.vm.nodeId).to.equal(wrapper.vm.treeId + '-' + wrapper.vm.model.label);
     });
   });
 
-  describe('when labelPropNames is specified', () => {
+  describe('when labelProperty is specified', () => {
 
-    beforeEach(() => {
-      wrapper = createWrapper(Object.assign(getDefaultPropsData(), {
-        labelPropNames: ['nope', 'id']
-      }));
+    beforeEach(async () => {
+      wrapper = createWrapper();
+      wrapper.vm.model.treeNodeSpec.labelProperty = 'id';
+      await wrapper.vm.$nextTick();
     });
 
-    it('has a labelPropName matching the first-avilable valid-label model property', () => {
+    it('has a labelPropName matching the labelProperty', () => {
       expect(wrapper.vm.labelPropName).to.equal('id');
     });
 
-    it('has a label of the first-avilable model[labelPropName] property', () => {
+    it('has a label of the  model[labelPropName] property', () => {
       expect(wrapper.text()).to.equal(wrapper.vm.model.id + '');
     });
   });
 
-  describe('when childrenPropNames is specified', () => {
+  describe('when childrenProperty is specified', () => {
 
-    describe('and a valid-children model property is specified', () => {
-
-      beforeEach(() => {
-        let defaultProps = getDefaultPropsData();
-        wrapper = createWrapper(Object.assign(defaultProps, {
-          childrenPropNames: ['nope', 'children'],
-          initialModel: generateNodes(['sf', ['s', 's']], defaultProps.radioGroupValues)[0]
-        }));
-      });
-
-      it('has a childrenPropName matching the first-avilable valid-children model property', () => {
-        expect(wrapper.vm.childrenPropName).to.equal('children');
-      });
-
-      it('has a children list of the first-avilable model[childrenPropName] property', () => {
-        expect(wrapper.vm.model.children.length).to.equal(2);
-      });
+    beforeEach(async () => {
+      let defaultProps = getDefaultPropsData();
+      wrapper = createWrapper(Object.assign(defaultProps, {
+        initialModel: generateNodes(['sf', ['s', 's']], defaultProps.radioGroupValues)[0]
+      }));
+      wrapper.vm.model.treeNodeSpec.childrenProperty = 'children';
+      await wrapper.vm.$nextTick();
     });
 
-    describe('and a valid-children model property is not specified', () => {
+    it('has a childrenPropName matching the valid-children model property', () => {
+      expect(wrapper.vm.childrenPropName).to.equal('children');
+    });
 
-      beforeEach(() => {
-        let defaultProps = getDefaultPropsData();
-        wrapper = createWrapper(Object.assign(defaultProps, {
-          childrenPropNames: ['nope', 'steve'],
-          initialModel: generateNodes(['sf', ['s', 's']], defaultProps.radioGroupValues)[0]
-        }));
-      });
-
-      it('has a childrenPropName of "children"', () => {
-        expect(wrapper.vm.childrenPropName).to.equal('children');
-      });
+    it('has a children list of the model[childrenPropName] property', () => {
+      expect(wrapper.vm.model[wrapper.vm.childrenPropName].length).to.equal(2);
     });
   });
 });

--- a/tests/unit/TreeViewNodeAria.spec.js
+++ b/tests/unit/TreeViewNodeAria.spec.js
@@ -20,10 +20,7 @@ const getDefaultPropsData = function () {
       insertItem: [45], // Insert
       deleteItem: [46] // Delete
     },
-    childrenPropNames: ['children'],
-    idPropNames: ['id'],
     initialModel: generateNodes(['cs'], radioState)[0],
-    labelPropNames: ['label'],
     modelDefaults: {},
     depth: 0,
     treeId: 'tree-id',
@@ -68,7 +65,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
     });
 
     it('has a tabindex of 0 if focusable', async () => {
-      wrapper.vm.model.focusable = true;
+      wrapper.vm.model.treeNodeSpec.focusable = true;
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.$el.attributes.tabindex.value).to.equal('0');
     });
@@ -97,18 +94,15 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
       wrapper = createWrapper({
         ariaKeyMap: {},
-        childrenPropNames: ['children'],
         depth: 0,
-        idPropNames: ['id'],
         initialModel,
-        labelPropNames: ['label'],
         modelDefaults: {},
         radioGroupValues: {}
       });
     });
 
     it('should have a boolean focusable property on the model', () => {
-      expect(wrapper.vm.model.focusable).to.be.a('boolean');
+      expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.a('boolean');
     });
   });
 
@@ -121,7 +115,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
     });
 
     it('should have focusable set to true', () => {
-      expect(wrapper.vm.model.focusable).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.true;
     });
 
     it('should focus the node', () => {
@@ -144,7 +138,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
     });
 
     it('should have focusable set to true', () => {
-      expect(wrapper.vm.model.focusable).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.true;
     });
   });
 
@@ -157,7 +151,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
     });
 
     it('should have state.selected set to true', () => {
-      expect(wrapper.vm.model.state.selected).to.be.false;
+      expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.false;
     });
   });
 
@@ -170,7 +164,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
     });
 
     it('should have state.selected set to true', () => {
-      expect(wrapper.vm.model.state.selected).to.be.true;
+      expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.true;
     });
   });
 
@@ -260,7 +254,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
           beforeEach(async () => {
             wrapper = createWrapper();
-            wrapper.vm.model.state.input.disabled = true;
+            wrapper.vm.model.treeNodeSpec.state.input.disabled = true;
             await triggerKeydown(wrapper, wrapper.vm.ariaKeyMap.activateItem[0]);
           });
 
@@ -295,7 +289,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
         });
 
         it('should not toggle state.selected', () => {
-          expect(wrapper.vm.model.state.selected).to.be.false;
+          expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.false;
         });
       });
 
@@ -309,7 +303,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
         });
 
         it('should toggle state.selected', () => {
-          expect(wrapper.vm.model.state.selected).to.be.true;
+          expect(wrapper.vm.model.treeNodeSpec.state.selected).to.be.true;
         });
       });
     });
@@ -328,7 +322,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
           it('expands the node', () => {
             expect(wrapper.emitted().treeViewNodeExpandedChange).to.be.an('array').that.has.length(1);
-            expect(wrapper.vm.model.state.expanded).to.be.true;
+            expect(wrapper.vm.model.treeNodeSpec.state.expanded).to.be.true;
           });
         });
 
@@ -342,7 +336,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
           it('focuses the first child', () => {
             expect(wrapper.emitted().treeViewNodeAriaFocusable).to.be.an('array').that.has.length(1);
-            expect(wrapper.vm.model.children[0].focusable).to.be.true;
+            expect(wrapper.vm.model.children[0].treeNodeSpec.focusable).to.be.true;
           });
         });
       });
@@ -375,7 +369,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
           it('focuses the parent node', () => {
             expect(wrapper.find('.tree-view-node-children').find(TreeViewNode).emitted().treeViewNodeAriaRequestParentFocus).to.be.an('array').that.has.length(1);
-            expect(wrapper.vm.model.focusable).to.be.true;
+            expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.true;
           });
         });
 
@@ -389,7 +383,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
           it('collapses the node', () => {
             expect(wrapper.emitted().treeViewNodeExpandedChange).to.be.an('array').that.has.length(1);
-            expect(wrapper.vm.model.focusable).to.be.true;
+            expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.true;
           });
         });
       });
@@ -404,7 +398,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
 
         it('focuses the parent node', () => {
           expect(wrapper.find('.tree-view-node-children').find(TreeViewNode).emitted().treeViewNodeAriaRequestParentFocus).to.be.an('array').that.has.length(1);
-          expect(wrapper.vm.model.focusable).to.be.true;
+          expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.true;
         });
       });
     });
@@ -534,7 +528,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
       });
 
       it('should set this node as focusable', () => {
-        expect(wrapper.vm.model.focusable).to.be.true;
+        expect(wrapper.vm.model.treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -548,7 +542,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
       });
 
       it('sets the last child of the previous sibling node as focusable', () => {
-        expect(wrapper.vm.model.children[0].children[1].focusable).to.be.true;
+        expect(wrapper.vm.model.children[0].children[1].treeNodeSpec.focusable).to.be.true;
       });
     });
 
@@ -562,7 +556,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
       });
 
       it('sets the previous sibling node as focusable', () => {
-        expect(wrapper.vm.model.children[0].focusable).to.be.true;
+        expect(wrapper.vm.model.children[0].treeNodeSpec.focusable).to.be.true;
       });
     });
   });
@@ -584,7 +578,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
         });
 
         it('should set its first child as focusable', () => {
-          expect(wrapper.vm.model.children[0].children[0].focusable).to.be.true;
+          expect(wrapper.vm.model.children[0].children[0].treeNodeSpec.focusable).to.be.true;
         });
       });
 
@@ -600,7 +594,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
           });
 
           it('should set the next sibling as focusable', () => {
-            expect(wrapper.vm.model.children[1].focusable).to.be.true;
+            expect(wrapper.vm.model.children[1].treeNodeSpec.focusable).to.be.true;
           });
         });
 
@@ -633,7 +627,7 @@ describe('TreeViewNode.vue (ARIA)', () => {
         });
 
         it('should set the next sibling as focusable', () => {
-          expect(wrapper.vm.model.children[1].focusable).to.be.true;
+          expect(wrapper.vm.model.children[1].treeNodeSpec.focusable).to.be.true;
         });
       });
 


### PR DESCRIPTION
This PR moves any tree-specific properties out of the model's root and into a treeNodeSpec property. This should help make it easier to inject existing models into the tree structure, and later decouple the two with a minimum of fuss.

Resolves #137 
