### PR TITLE
Fix initial focus stealing

### DIFF
--- a/docsrc/generateDocs.ps1
+++ b/docsrc/generateDocs.ps1
@@ -9,9 +9,15 @@ if (-not [System.String]::IsNullOrEmpty($siteRoot)) {
 
     $metafile = (Join-Path -Path $PSScriptRoot -ChildPath "metadata.demo.yaml")
     # Replace TreeView package references
-    (Get-Content $metafile) -replace 'http://localhost:8082', ( -Join ('https://unpkg.com/@grapoza/vue-tree@', $env:package_version)) | Set-Content $metafile
+    # Replace full JS with minified
     # replace CSS paths
-    (Get-Content $metafile) -replace '/style/demo/', ( -Join ($siteRoot, '/style/demo/')) | Set-Content $metafile
+    (Get-Content $metafile) | ForEach-Object {
+        $_ -replace 'http://localhost:8082', ( -Join ('https://unpkg.com/@grapoza/vue-tree@', $env:package_version)) `
+           -replace 'dist/vue.js',           'dist/vue.min.js' `
+           -replace '/vue-tree.umd.js',      '/vue-tree.umd.min.js' `
+           -replace '/style/demo/',          ( -Join ($siteRoot, '/style/demo/'))
+    } |
+    Set-Content $metafile
 }
 
 Get-ChildItem $PSScriptRoot\*  -Recurse -Include *.md, *.css, *.js, *.png | Where-Object { -not $_.PsIsContainer -and $_.DirectoryName -notmatch 'output' } |

--- a/docsrc/metadata.demo.yaml
+++ b/docsrc/metadata.demo.yaml
@@ -2,8 +2,8 @@
 header-includes:
 - |
   ```{=html}
-  <script src="https://unpkg.com/vue/dist/vue.min.js"></script>
-  <script src="http://localhost:8082/vue-tree.umd.min.js"></script>
+  <script src="https://unpkg.com/vue/dist/vue.js"></script>
+  <script src="http://localhost:8082/vue-tree.umd.js"></script>
   <link rel="stylesheet" href="http://localhost:8082/vue-tree.css">
   <link rel="stylesheet" href="/style/demo/demo.css">
   <link rel="stylesheet" href="/style/demo/grayscale.css">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Yet another Vue treeview component.",
   "author": "Gregg Rapoza <grapoza@gmail.com>",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/vue-tree.umd.min.js",
   "browser": "index.js",
   "repository": {

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -11,6 +11,7 @@
                     :initial-model="nodeModel"
                     :selection-mode="selectionMode"
                     :tree-id="uniqueId"
+                    :is-mounted="isMounted"
                     :initial-radio-group-values="radioGroupValues"
                     @treeViewNodeClick="(t, e)=>$emit('treeViewNodeClick', t, e)"
                     @treeViewNodeDblclick="(t, e)=>$emit('treeViewNodeDblclick', t, e)"
@@ -82,7 +83,8 @@
       return {
         uniqueId: null,
         model: this.initialModel,
-        radioGroupValues: {}
+        radioGroupValues: {},
+        isMounted: false
       };
     },
     computed: {
@@ -95,6 +97,13 @@
     mounted() {
       this.$_treeView_enforceSingleSelectionMode();
       this.$set(this, 'uniqueId', this.$el.id ? this.$el.id : null);
+
+      // Set this in a $nextTick so the focusable watcher
+      // in TreeViewNodeAria fires before isMounted is set.
+      // Otherwise, it steals focus when the tree is mounted.
+      this.$nextTick(() => {
+        this.isMounted = true;
+      });
     },
     methods: {
       getCheckedCheckboxes() {

--- a/src/components/TreeViewNode.vue
+++ b/src/components/TreeViewNode.vue
@@ -151,6 +151,7 @@
                       :tree-id="treeId"
                       :initial-radio-group-values="radioGroupValues"
                       :aria-key-map="ariaKeyMap"
+                      :is-mounted="isMounted"
                       @treeViewNodeClick="(t, e)=>$emit('treeViewNodeClick', t, e)"
                       @treeViewNodeDblclick="(t, e)=>$emit('treeViewNodeDblclick', t, e)"
                       @treeViewNodeCheckboxChange="(t, e)=>$emit('treeViewNodeCheckboxChange', t, e)"
@@ -194,6 +195,10 @@
       },
       initialModel: {
         type: Object,
+        required: true
+      },
+      isMounted: {
+        type: Boolean,
         required: true
       },
       modelDefaults: {
@@ -470,7 +475,7 @@
         this.$emit('treeViewNodeExpandedChange', this.model, event);
       },
       $_treeViewNode_toggleSelected(event) {
-        // Note that selection change is already handled by the "model.focusable" watcher
+        // Note that selection change is already handled by the "model.treeNodeSpec.focusable" watcher
         // method in TreeViewNodeAria if selectionMode is selectionFollowsFocus.
         if (this.model.treeNodeSpec.selectable && ['single', 'multiple'].includes(this.selectionMode)) {
           this.model.treeNodeSpec.state.selected = !this.model.treeNodeSpec.state.selected;

--- a/src/mixins/TreeViewAria.js
+++ b/src/mixins/TreeViewAria.js
@@ -85,7 +85,7 @@ export default {
         this.$_treeView_enforceSingleSelectionMode();
       }
       else if (this.selectionMode === 'selectionFollowsFocus') {
-        // Make sure the actual focused item is selected if the mode changes, and deselect all others
+        // Make sure the actual focusable item is selected if the mode changes, and deselect all others
         this.$_treeView_depthFirstTraverse((node) => {
           let idPropName = node.treeNodeSpec.idProperty;
           let focusableIdPropName = this.focusableNodeModel.treeNodeSpec.idProperty;
@@ -101,11 +101,13 @@ export default {
       }
     },
     $_treeViewAria_handleFocusableChange(newNodeModel) {
-      if (this.focusableNodeModel) {
-        this.focusableNodeModel.treeNodeSpec.focusable = false;
-      }
+      if (this.focusableNodeModel !== newNodeModel) {
+        if (this.focusableNodeModel) {
+          this.focusableNodeModel.treeNodeSpec.focusable = false;
+        }
 
-      this.$set(this, 'focusableNodeModel', newNodeModel);
+        this.$set(this, 'focusableNodeModel', newNodeModel);
+      }
     },
     $_treeViewAria_focusFirstNode() {
       this.model[0].treeNodeSpec.focusable = true;

--- a/src/mixins/TreeViewNodeAria.js
+++ b/src/mixins/TreeViewNodeAria.js
@@ -15,9 +15,12 @@ export default {
   },
   watch: {
     'model.treeNodeSpec.focusable': function(newValue) {
-      // If focusable is set to true, also focus the treeitem element.
       if (newValue === true) {
-        this.$el.focus();
+        // If focusable is set to true and the tree is mounted in the DOM,
+        // also focus the node's element.
+        if (this.isMounted) {
+          this.$el.focus();
+        }
         this.$emit('treeViewNodeAriaFocusable', this.model);
       }
 

--- a/tests/unit/TreeViewNode.customizations.spec.js
+++ b/tests/unit/TreeViewNode.customizations.spec.js
@@ -23,7 +23,8 @@ const getDefaultPropsData = function () {
     modelDefaults: {},
     depth: 0,
     treeId: 'tree-id',
-    initialRadioGroupValues: {}
+    initialRadioGroupValues: {},
+    isMounted: false
   }
 };
 
@@ -80,7 +81,8 @@ describe('TreeViewNode.vue (customizations)', () => {
         depth: 0,
         treeId: 'tree',
         initialRadioGroupValues: {},
-        selectionMode: 'single'
+        selectionMode: 'single',
+        isMounted: false
       });
     });
 
@@ -196,7 +198,8 @@ describe('TreeViewNode.vue (customizations)', () => {
             modelDefaults: { customizations: { classes: customClasses } },
             depth: 0,
             treeId: 'tree',
-            initialRadioGroupValues: {}
+            initialRadioGroupValues: {},
+            isMounted: false
           },
           {
             text: '<span :id="props.model.id" class="text-slot-content"><span class="slot-custom-classes">{{ JSON.stringify(props.customClasses) }}</span></span>',
@@ -231,7 +234,8 @@ describe('TreeViewNode.vue (customizations)', () => {
             modelDefaults: { customizations: { classes: customClasses } },
             depth: 0,
             treeId: 'tree',
-            initialRadioGroupValues: {}
+            initialRadioGroupValues: {},
+            isMounted: false
           },
           {
             checkbox: `<span :id="props.model.id" class="text-slot-content">
@@ -278,7 +282,8 @@ describe('TreeViewNode.vue (customizations)', () => {
             modelDefaults: { customizations: { classes: customClasses } },
             depth: 0,
             treeId: 'tree',
-            initialRadioGroupValues: {}
+            initialRadioGroupValues: {},
+            isMounted: false
           },
           {
             radio: `<span :id="props.model.id" class="text-slot-content">

--- a/tests/unit/TreeViewNode.interactions.spec.js
+++ b/tests/unit/TreeViewNode.interactions.spec.js
@@ -24,6 +24,7 @@ const getDefaultPropsData = function () {
     depth: 0,
     treeId: 'tree-id',
     initialRadioGroupValues: {},
+    isMounted: false,
     selectionMode: 'multiple'
   }
 };
@@ -116,7 +117,8 @@ describe('TreeViewNode.vue (interactions)', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
 
       expander = wrapper.find('#' + wrapper.vm.expanderId);
@@ -184,7 +186,8 @@ describe('TreeViewNode.vue (interactions)', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
 
       radioButton = wrapper.find('#' + wrapper.vm.inputId);
@@ -224,7 +227,8 @@ describe('TreeViewNode.vue (interactions)', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
 
       deleteButton = wrapper.find('#' + wrapper.vm.$children[0].nodeId + '-delete');
@@ -258,7 +262,8 @@ describe('TreeViewNode.vue (interactions)', () => {
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
-          initialRadioGroupValues: {}
+          initialRadioGroupValues: {},
+          isMounted: false
         });
 
         addChildButton = wrapper.find('#' + wrapper.vm.nodeId + '-add-child');
@@ -294,7 +299,8 @@ describe('TreeViewNode.vue (interactions)', () => {
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
-          initialRadioGroupValues: {}
+          initialRadioGroupValues: {},
+          isMounted: false
         });
 
         addChildButton = wrapper.find('#' + wrapper.vm.nodeId + '-add-child');

--- a/tests/unit/TreeViewNode.spec.js
+++ b/tests/unit/TreeViewNode.spec.js
@@ -13,6 +13,7 @@ const getDefaultPropsData = function () {
     depth: 0,
     treeId: 'tree-id',
     initialRadioGroupValues: {},
+    isMounted: false,
     selectionMode: 'multiple'
   }
 };
@@ -45,7 +46,8 @@ describe('TreeViewNode.vue', () => {
         depth: 0,
         initialModel,
         modelDefaults: {},
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
     });
 
@@ -81,7 +83,8 @@ describe('TreeViewNode.vue', () => {
           }
         },
         initialRadioGroupValues: {},
-        selectionMode: 'multiple'
+        selectionMode: 'multiple',
+        isMounted: false
       });
     });
 
@@ -103,7 +106,8 @@ describe('TreeViewNode.vue', () => {
         depth: 0,
         initialModel: { id: 'my-node', label: 'My Node', treeNodeSpec: { title: 'My Title' } },
         modelDefaults: {},
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
     });
 
@@ -158,7 +162,8 @@ describe('TreeViewNode.vue', () => {
         initialModel: generateNodes(['ces'])[0],
         modelDefaults: {},
         depth: 0,
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
     });
 
@@ -186,7 +191,8 @@ describe('TreeViewNode.vue', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
 
       addChildButton = wrapper.find('#' + wrapper.vm.nodeId + '-add-child');
@@ -212,7 +218,8 @@ describe('TreeViewNode.vue', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
 
       addChildButton = wrapper.find('#' + wrapper.vm.nodeId + '-add-child');
@@ -238,7 +245,8 @@ describe('TreeViewNode.vue', () => {
         modelDefaults: { addChildCallback },
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
 
       addChildButton = wrapper.find('#' + wrapper.vm.nodeId + '-add-child');
@@ -260,7 +268,8 @@ describe('TreeViewNode.vue', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
     });
 
@@ -296,7 +305,8 @@ describe('TreeViewNode.vue', () => {
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
-          initialRadioGroupValues: {}
+          initialRadioGroupValues: {},
+          isMounted: false
         });
       });
 
@@ -334,7 +344,8 @@ describe('TreeViewNode.vue', () => {
             modelDefaults: {},
             depth: 0,
             treeId: 'tree',
-            initialRadioGroupValues: {}
+            initialRadioGroupValues: {},
+            isMounted: false
           });
         });
 
@@ -366,7 +377,8 @@ describe('TreeViewNode.vue', () => {
           modelDefaults: {},
           depth: 0,
           treeId: 'tree',
-          initialRadioGroupValues: {}
+          initialRadioGroupValues: {},
+          isMounted: false
         });
       });
 
@@ -389,7 +401,8 @@ describe('TreeViewNode.vue', () => {
         modelDefaults: {},
         depth: 0,
         treeId: 'tree',
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
     });
 
@@ -416,7 +429,8 @@ describe('TreeViewNode.vue', () => {
         depth: 0,
         treeId: 'tree',
         initialRadioGroupValues: {},
-        selectionMode: null
+        selectionMode: null,
+        isMounted: false
       });
     });
 
@@ -438,7 +452,8 @@ describe('TreeViewNode.vue', () => {
         depth: 0,
         treeId: 'tree',
         initialRadioGroupValues: {},
-        selectionMode: 'multiple'
+        selectionMode: 'multiple',
+        isMounted: false
       });
     });
 
@@ -462,7 +477,8 @@ describe('TreeViewNode.vue', () => {
           depth: 0,
           treeId: 'tree',
           initialRadioGroupValues: {},
-          selectionMode: 'single'
+          selectionMode: 'single',
+          isMounted: false
         });
       });
 
@@ -484,7 +500,8 @@ describe('TreeViewNode.vue', () => {
           depth: 0,
           treeId: 'tree',
           initialRadioGroupValues: {},
-          selectionMode: 'single'
+          selectionMode: 'single',
+          isMounted: false
         });
       });
 
@@ -509,7 +526,8 @@ describe('TreeViewNode.vue', () => {
           depth: 0,
           treeId: 'tree',
           initialRadioGroupValues: {},
-          selectionMode: 'selectionFollowsFocus'
+          selectionMode: 'selectionFollowsFocus',
+          isMounted: false
         });
       });
 
@@ -531,7 +549,8 @@ describe('TreeViewNode.vue', () => {
           depth: 0,
           treeId: 'tree',
           initialRadioGroupValues: {},
-          selectionMode: 'selectionFollowsFocus'
+          selectionMode: 'selectionFollowsFocus',
+          isMounted: false
         });
       });
 
@@ -556,7 +575,8 @@ describe('TreeViewNode.vue', () => {
           depth: 0,
           treeId: 'tree',
           initialRadioGroupValues: {},
-          selectionMode: 'multiple'
+          selectionMode: 'multiple',
+          isMounted: false
         });
       });
 
@@ -578,7 +598,8 @@ describe('TreeViewNode.vue', () => {
           depth: 0,
           treeId: 'tree',
           initialRadioGroupValues: {},
-          selectionMode: 'multiple'
+          selectionMode: 'multiple',
+          isMounted: false
         });
       });
 

--- a/tests/unit/TreeViewNodeAria.spec.js
+++ b/tests/unit/TreeViewNodeAria.spec.js
@@ -23,18 +23,22 @@ const getDefaultPropsData = function () {
     modelDefaults: {},
     depth: 0,
     treeId: 'tree-id',
-    initialRadioGroupValues: {}
+    initialRadioGroupValues: {},
+    isMounted: false
   }
 };
 
 function createWrapper(customPropsData, slotsData) {
-  return mount(TreeViewNode, {
+  var wrapper = mount(TreeViewNode, {
     sync: false,
     propsData: customPropsData || getDefaultPropsData(),
     localVue,
     scopedSlots: slotsData,
     attachToDocument: true
   });
+
+  wrapper.setProps({ isMounted: true });
+  return wrapper;
 }
 
 async function triggerKeydown(wrapper, keyCode) {
@@ -96,7 +100,8 @@ describe('TreeViewNode.vue (ARIA)', () => {
         depth: 0,
         initialModel,
         modelDefaults: {},
-        initialRadioGroupValues: {}
+        initialRadioGroupValues: {},
+        isMounted: false
       });
     });
 


### PR DESCRIPTION
The focus stealing was caused by the `model.treeNodeSpec.focusable` watcher grabbing focus as the tree focus properties were initialized on mount. There is now an `isMounted` prop on nodes which is checked when handling the watcher to control whether it actually takes focus in the DOM. `isMounted` is updated by the top-level tree mount in a $nextTick to allow the initial watcher invocations to run without stealing focus.

closes #148