### PR TITLE
Add asynchronous loading for root nodes

### DIFF
--- a/docsrc/demos.md
+++ b/docsrc/demos.md
@@ -835,7 +835,7 @@ The convenience method `getSelected` is exposed on the tree component to make it
 <!--- -------------------------------------------------------------------------------------- --->
 ### Slots
 
-A treeview has slots available for replacing specific types of nodes. The `text`, `checkbox`, `radio`, and `loading` slots replace the correpsonding types of nodes. For more info, see [the docs](./#slots).
+A treeview has slots available for replacing specific types of nodes. The `text`, `checkbox`, `radio`, `loading-root` and `loading` slots replace the correpsonding types of nodes. For more info, see [the docs](./#slots).
 
 ```{=html5}
 <details>
@@ -852,7 +852,10 @@ A treeview has slots available for replacing specific types of nodes. The `text`
   <template v-slot:radio="{ model, customClasses, inputId, inputModel, radioChangeHandler }">
     content
   </template>
-  <template v-slot:text="{ model, customClasses }">
+  <template v-slot:loading="{ model, customClasses }">
+    content
+  </template>
+  <template v-slot:loading-root>
     content
   </template>
 </tree>
@@ -1054,14 +1057,18 @@ A treeview has slots available for replacing specific types of nodes. The `text`
 <!--- -------------------------------------------------------------------------------------- --->
 ### Asynchronous Loading
 
-Child nodes can be loaded asynchronously by providing a function to the `loadChildrenAsync` property in a node's `treeNodeSpec` (or use `modelDefaults` to use the same method for all nodes). The `loadChildrenAsync` can take the parent node's model data as an argument, and should return a Promise that resolves to an array of model data to add as children.
+Two types of asynchronous loading are available. The first loads the root data for the treeview itself, and the second asynchronously loads child data when a node is expanded.
+
+You can load root nodes asynchronously by providing a function to the `loadNodesAsync` property of the treeview. The function should return a Promise that resolves to an array of model data to add as root nodes.
+
+You can load child nodes asynchronously by providing a function to the `loadChildrenAsync` property in a node's `treeNodeSpec` (or use `modelDefaults` to use the same method for all nodes). The function can take the parent node's model data as an argument, and should return a Promise that resolves to an array of model data to add as children.
 
 ```{=html5}
 <details>
 <summary>
 ```
 ```html
-<tree id="customtree-async" :initial-model="model" :model-defaults="modelDefaults"></tree>
+<tree id="customtree-async" :load-nodes-async="loadNodesAsync" :model-defaults="modelDefaults"></tree>
 ```
 ```{=html5}
 </summary>
@@ -1069,7 +1076,7 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
 <!--- The leading spaces are to render the html aligned correctly --->
 ```html
   <div id="app-async" class="demo-tree">
-  <tree id="customtree-async" :initial-model="model" :model-defaults="modelDefaults"></tree>
+  <tree id="customtree-async" :load-nodes-async="loadNodesAsync" :model-defaults="modelDefaults"></tree>
 </div>
 <script type='module'>
   import TreeView from "@grapoza/vue-tree"
@@ -1079,12 +1086,6 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
     },
     data() {
       return {
-        model: [
-          {
-            id: "async-rootnode",
-            label: "Root Node"
-          }
-        ],
         modelDefaults: {
           loadChildrenAsync: this.loadChildrenAsync,
           deleteTitle: 'Delete this node',
@@ -1093,7 +1094,7 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
       };
     },
     methods: {
-      loadChildrenAsync(parentModel) {
+      async loadChildrenAsync(parentModel) {
         const id = Date.now();
         return new Promise(resolve => setTimeout(resolve.bind(null, [
           {
@@ -1104,6 +1105,14 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
             id: `async-child-node-${id}-2`,
             label: `Child ${id}-2`,
             treeNodeSpec: { deletable: true }
+          }
+        ]), 1000));
+      },
+      async loadNodesAsync() {
+        return new Promise(resolve => setTimeout(resolve.bind(null, [
+          {
+            id: "async-rootnode",
+            label: "Root Node"
           }
         ]), 1000));
       }
@@ -1117,7 +1126,7 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
 
 ```{=html5}
 <div id="app-async" class="demo-tree">
-    <tree id="customtree-async" :initial-model="model" :model-defaults="modelDefaults"></tree>
+    <tree id="customtree-async" :load-nodes-async="loadNodesAsync" :model-defaults="modelDefaults"></tree>
 </div>
 <script type='module'>
     new Vue({
@@ -1126,13 +1135,6 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
       },
       data() {
         return {
-            childCounter: 0,
-            model: [
-            {
-                id: "async-rootnode",
-                label: "Root Node"
-            }
-            ],
             modelDefaults: {
                 loadChildrenAsync: this.loadChildrenAsync,
                 deleteTitle: 'Delete this node',
@@ -1141,7 +1143,7 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
         };
       },
       methods: {
-        loadChildrenAsync(parentModel) {
+        async loadChildrenAsync(parentModel) {
           const id = Date.now();
           return new Promise(resolve => setTimeout(resolve.bind(null, [
             {
@@ -1152,6 +1154,14 @@ Child nodes can be loaded asynchronously by providing a function to the `loadChi
               id: `async-child-node-${id}-2`,
               label: `Child ${id}-2`,
               treeNodeSpec: { deletable: true }
+            }
+          ]), 1000));
+        },
+        async loadNodesAsync() {
+          return new Promise(resolve => setTimeout(resolve.bind(null, [
+            {
+              id: "async-rootnode",
+              label: "Root Node"
             }
           ]), 1000));
         }

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -1,49 +1,59 @@
 <template>
-  <ul class="grtv"
-      :class="skinClass"
-      role="tree"
-      :aria-multiselectable="ariaMultiselectable">
-    <tree-view-node v-for="(nodeModel) in model"
-                    :key="nodeModel[nodeModel.treeNodeSpec && nodeModel.treeNodeSpec.idProperty ? nodeModel.treeNodeSpec.idProperty : 'id']"
-                    :aria-key-map="ariaKeyMap"
-                    :depth="0"
-                    :model-defaults="modelDefaults"
-                    :initial-model="nodeModel"
-                    :selection-mode="selectionMode"
-                    :tree-id="uniqueId"
-                    :is-mounted="isMounted"
-                    :initial-radio-group-values="radioGroupValues"
-                    @treeViewNodeClick="(t, e)=>$emit(TvEvent.Click, t, e)"
-                    @treeViewNodeDblclick="(t, e)=>$emit(TvEvent.DoubleClick, t, e)"
-                    @treeViewNodeCheckboxChange="(t, e)=>$emit(TvEvent.CheckboxChange, t, e)"
-                    @treeViewNodeRadioChange="(t, e)=>$emit(TvEvent.RadioChange, t, e)"
-                    @treeViewNodeExpandedChange="(t, e)=>$emit(TvEvent.ExpandedChange, t, e)"
-                    @treeViewNodeChildrenLoad="(t, e)=>$emit(TvEvent.ChildrenLoad, t, e)"
-                    @treeViewNodeSelectedChange="$_grtv_handleNodeSelectedChange"
-                    @treeViewNodeAdd="(t, p, e)=>$emit(TvEvent.Add, t, p, e)"
-                    @treeViewNodeDelete="$_grtv_handleChildDeletion"
-                    @treeViewNodeAriaFocusableChange="$_grtvAria_handleFocusableChange"
-                    @treeViewNodeAriaRequestFirstFocus="$_grtvAria_focusFirstNode"
-                    @treeViewNodeAriaRequestLastFocus="$_grtvAria_focusLastNode"
-                    @treeViewNodeAriaRequestPreviousFocus="$_grtvAria_handlePreviousFocus"
-                    @treeViewNodeAriaRequestNextFocus="$_grtvAria_handleNextFocus"
-                    @treeViewNodeDragMove="$_grtvDnd_dragMoveNode"
-                    @treeViewNodeDrop="$_grtvDnd_drop">
+  <div class="grtv-wrapper"
+       :class="skinClass">
+    <slot v-if="!areNodesLoaded"
+          name="loading-root">
 
-      <template #checkbox="{ model, customClasses, inputId, checkboxChangeHandler }">
-        <slot name="checkbox" :model="model" :customClasses="customClasses" :inputId="inputId" :checkboxChangeHandler="checkboxChangeHandler"></slot>
-      </template>
-      <template #radio="{ model, customClasses, inputId, inputModel, radioChangeHandler }">
-        <slot name="radio" :model="model" :customClasses="customClasses" :inputId="inputId" :inputModel="inputModel" :radioChangeHandler="radioChangeHandler"></slot>
-      </template>
-      <template #text="{ model, customClasses }">
-        <slot name="text" :model="model" :customClasses="customClasses"></slot>
-      </template>
-      <template #loading="{ model, customClasses }">
-        <slot name="loading" :model="model" :customClasses="customClasses"></slot>
-      </template>
-    </tree-view-node>
-  </ul>
+      <span class="grtv-loading">
+        ...
+      </span>
+    </slot>
+    <ul class="grtv"
+        role="tree"
+        :aria-multiselectable="ariaMultiselectable"
+        v-if="areNodesLoaded">
+      <tree-view-node v-for="(nodeModel) in model"
+                      :key="nodeModel[nodeModel.treeNodeSpec && nodeModel.treeNodeSpec.idProperty ? nodeModel.treeNodeSpec.idProperty : 'id']"
+                      :aria-key-map="ariaKeyMap"
+                      :depth="0"
+                      :model-defaults="modelDefaults"
+                      :initial-model="nodeModel"
+                      :selection-mode="selectionMode"
+                      :tree-id="uniqueId"
+                      :is-mounted="isMounted"
+                      :initial-radio-group-values="radioGroupValues"
+                      @treeViewNodeClick="(t, e)=>$emit(TvEvent.Click, t, e)"
+                      @treeViewNodeDblclick="(t, e)=>$emit(TvEvent.DoubleClick, t, e)"
+                      @treeViewNodeCheckboxChange="(t, e)=>$emit(TvEvent.CheckboxChange, t, e)"
+                      @treeViewNodeRadioChange="(t, e)=>$emit(TvEvent.RadioChange, t, e)"
+                      @treeViewNodeExpandedChange="(t, e)=>$emit(TvEvent.ExpandedChange, t, e)"
+                      @treeViewNodeChildrenLoad="(t, e)=>$emit(TvEvent.ChildrenLoad, t, e)"
+                      @treeViewNodeSelectedChange="$_grtv_handleNodeSelectedChange"
+                      @treeViewNodeAdd="(t, p, e)=>$emit(TvEvent.Add, t, p, e)"
+                      @treeViewNodeDelete="$_grtv_handleChildDeletion"
+                      @treeViewNodeAriaFocusableChange="$_grtvAria_handleFocusableChange"
+                      @treeViewNodeAriaRequestFirstFocus="$_grtvAria_focusFirstNode"
+                      @treeViewNodeAriaRequestLastFocus="$_grtvAria_focusLastNode"
+                      @treeViewNodeAriaRequestPreviousFocus="$_grtvAria_handlePreviousFocus"
+                      @treeViewNodeAriaRequestNextFocus="$_grtvAria_handleNextFocus"
+                      @treeViewNodeDragMove="$_grtvDnd_dragMoveNode"
+                      @treeViewNodeDrop="$_grtvDnd_drop">
+
+        <template #checkbox="{ model, customClasses, inputId, checkboxChangeHandler }">
+          <slot name="checkbox" :model="model" :customClasses="customClasses" :inputId="inputId" :checkboxChangeHandler="checkboxChangeHandler"></slot>
+        </template>
+        <template #radio="{ model, customClasses, inputId, inputModel, radioChangeHandler }">
+          <slot name="radio" :model="model" :customClasses="customClasses" :inputId="inputId" :inputModel="inputModel" :radioChangeHandler="radioChangeHandler"></slot>
+        </template>
+        <template #text="{ model, customClasses }">
+          <slot name="text" :model="model" :customClasses="customClasses"></slot>
+        </template>
+        <template #loading="{ model, customClasses }">
+          <slot name="loading" :model="model" :customClasses="customClasses"></slot>
+        </template>
+      </tree-view-node>
+    </ul>
+  </div>
 </template>
 
 <script>
@@ -66,7 +76,13 @@
     props: {
       initialModel: {
         type: Array,
-        required: true
+        required: false,
+        default: function () { return []; }
+      },
+      loadNodesAsync: {
+        type: Function,
+        required: false,
+        default: null
       },
       modelDefaults: {
         type: Object,
@@ -92,13 +108,17 @@
     },
     data() {
       return {
-        uniqueId: null,
+        areNodesAsyncLoaded: false,
+        isMounted: false,
         model: this.initialModel,
         radioGroupValues: {},
-        isMounted: false
+        uniqueId: null
       };
     },
     computed: {
+      areNodesLoaded() {
+        return typeof this.loadNodesAsync !== 'function' || this.areNodesAsyncLoaded;
+      },
       ariaMultiselectable() {
         // If there's no selectionMode, return a boolean so aria-multiselectable isn't included.
         // Otherwise, return either the string 'true' or 'false' as the attribute's value.
@@ -113,7 +133,20 @@
       // it will be set to the element ID if one is present.
       this.$set(this, 'uniqueId', generateUniqueId());
     },
-    mounted() {
+    async mounted() {
+
+      // If nodes need to be loaded asynchronously, load them.
+      if (!this.areNodesLoaded) {
+
+        var nodesResult = await this.loadNodesAsync();
+
+        if (nodesResult) {
+          this.areNodesAsyncLoaded = true;
+          this.model.splice(0, this.model.length, ...nodesResult);
+          this.$emit(TvEvent.RootNodesLoad, this.model);
+        }
+      }
+
       this.$_grtv_enforceSingleSelectionMode();
 
       if (this.$el.id) {
@@ -337,10 +370,13 @@
 <style lang="scss">
 
   // Embedded SCSS is the 'grtv-default-skin' skin
-  .grtv.grtv-default-skin {
-    margin: 0;
-    padding: 0;
-    list-style: none;
+  .grtv-wrapper.grtv-default-skin {
+
+    > .grtv {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
   }
 
 </style>

--- a/src/components/TreeViewNode.vue
+++ b/src/components/TreeViewNode.vue
@@ -701,7 +701,7 @@
   $itemSpacing: 1.2rem;
 
   // Everything's in a .grtv (embedded SCSS is the 'grtv-default-skin' skin)
-  .grtv.grtv-default-skin {
+  .grtv-wrapper.grtv-default-skin {
 
     // The node, including its content and children list
     .grtvn {

--- a/src/enums/event.js
+++ b/src/enums/event.js
@@ -1,4 +1,7 @@
 const events = Object.freeze({
+    // Root tree state
+    RootNodesLoad: 'treeViewRootNodesLoad',
+
     // Node state
     Click: 'treeViewNodeClick',
     DoubleClick: 'treeViewNodeDblclick',

--- a/tests/local/async.html
+++ b/tests/local/async.html
@@ -14,13 +14,11 @@
   <div class="container">
     <h1>Async Loading Usage</h1>
     <div id="app">
-      <tree id="customtree" :initial-model="model" :model-defaults="modelDefaults" ref="tree"></tree>
+      <tree id="customtree" :load-nodes-async="loadNodesAsync" :model-defaults="modelDefaults" ref="tree"></tree>
     </div>
   </div>
 
   <script type='module'>
-    import asyncData from './async.js';
-
     new Vue({
       components: {
         tree: window['vue-tree']
@@ -28,7 +26,7 @@
       data() {
         return {
           childCounter: 0,
-          model: asyncData,
+          loadNodesAsync: this.loadRootNodesCallback,
           modelDefaults: {
             loadChildrenAsync: this.loadChildrenCallback,
             deletable: true
@@ -36,10 +34,13 @@
         };
       },
       methods: {
-        loadChildrenCallback(parentModel) {
+        async loadChildrenCallback(parentModel) {
           this.childCounter++;
           let currentCounter = this.childCounter;
           return new Promise(resolve => setTimeout(resolve.bind(null, [{ id: `child-node${currentCounter}`, label: `Child ${currentCounter}` }]), 1000));
+        },
+        async loadRootNodesCallback() {
+          return new Promise(resolve => setTimeout(resolve.bind(null, [{ id: 'rootNode', label: 'Root Node', treeNodeSpec: { deletable: false } } ]), 1000));
         }
       }
     }).$mount('#app');

--- a/tests/local/async.js
+++ b/tests/local/async.js
@@ -1,9 +1,0 @@
-export default [
-    {
-        id: 'rootNode',
-        label: 'Root Node',
-        treeNodeSpec: {
-            deletable: false
-        }
-    }
-];

--- a/tests/unit/TreeViewAria.spec.js
+++ b/tests/unit/TreeViewAria.spec.js
@@ -42,7 +42,7 @@ describe('TreeView.vue (ARIA)', () => {
     });
 
     it('should have an ARIA role of tree', () => {
-      expect(wrapper.vm.$el.attributes.role.value).to.equal('tree');
+      expect(wrapper.find('.grtv').element.attributes.role.value).to.equal('tree');
     });
   });
 

--- a/tests/unit/TreeViewNode.interactions.spec.js
+++ b/tests/unit/TreeViewNode.interactions.spec.js
@@ -173,8 +173,11 @@ describe('TreeViewNode.vue (interactions)', () => {
         jest.useRealTimers();
       });
 
-      it('should show the loading area while children load', () => {
-        expect(wrapper.find('.grtvn-loading').exists()).to.be.true;
+      describe('and the the loadChildrenAsync Promise has not returned', () => {
+
+        it('should show the loading area while children load', () => {
+          expect(wrapper.find('.grtvn-loading').exists()).to.be.true;
+        });
       });
 
       describe('and the loadChildrenAsync Promise returns', () => {


### PR DESCRIPTION
Adds the ability to load the root nodes of the tree by providing an asynchronous callback to the `loadRootNodes` property of the tree view. If present, the results of that function will overwrite anything provided to the `initialModel` property, which is now optional and defaults to an empty array. New markup is included for a loading placeholder, and a wrapper div was added for the loader slot and tree list.

Closes #194 
