### PR TITLE
Move selection mode enforcement to nextTick

### DIFF
--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -147,16 +147,17 @@
         }
       }
 
-      this.$_grtv_enforceSingleSelectionMode();
-
       if (this.$el.id) {
         this.$set(this, 'uniqueId', this.$el.id);
       }
 
-      // Set this in a $nextTick so the focusable watcher
+      // Set isMounted in a $nextTick so the focusable watcher
       // in TreeViewNodeAria fires before isMounted is set.
       // Otherwise, it steals focus when the tree is mounted.
+      // Also wait to enforce single selection mode in case root
+      // nodes load asynchronously so their create hooks fire.
       this.$nextTick(() => {
+        this.$_grtv_enforceSingleSelectionMode();
         this.isMounted = true;
       });
     },

--- a/tests/unit/TreeView.spec.js
+++ b/tests/unit/TreeView.spec.js
@@ -229,7 +229,7 @@ describe('TreeView.vue', () => {
     beforeEach(() => {
       jest.useFakeTimers();
       loadNodesPromise = new Promise(resolve => setTimeout(resolve.bind(null, generateNodes(['', ''])), 1000));
-      wrapper = createWrapper({ loadNodesAsync: () => loadNodesPromise });
+      wrapper = createWrapper({ loadNodesAsync: () => loadNodesPromise, selectionMode: SelectionMode.Single });
     });
 
     afterEach(() => {


### PR DESCRIPTION
When root tree nodes are loaded asyncrhronously the $_grtv_enforceSingleSelectionMode method could fire before the nodes were fully initialized. Moving this to the nextTick handler ensures this issue does not occur.
