### PR TITLE
Move selection mode enforcement to nextTick

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grapoza/vue-tree",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Yet another Vue treeview component.",
   "author": "Gregg Rapoza <grapoza@gmail.com>",
   "license": "MIT",

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -160,16 +160,17 @@
         }
       }
 
-      this.$_grtv_enforceSingleSelectionMode();
-
       if (this.$refs.treeElement.id) {
         this.uniqueId = this.$refs.treeElement.id;
       }
 
-      // Set this in a $nextTick so the focusable watcher
+      // Set isMounted in a $nextTick so the focusable watcher
       // in TreeViewNodeAria fires before isMounted is set.
       // Otherwise, it steals focus when the tree is mounted.
+      // Also wait to enforce single selection mode in case root
+      // nodes load asynchronously so their create hooks fire.
       this.$nextTick(() => {
+        this.$_grtv_enforceSingleSelectionMode();
         this.isMounted = true;
       });
     },

--- a/tests/unit/TreeView.spec.js
+++ b/tests/unit/TreeView.spec.js
@@ -225,7 +225,7 @@ describe('TreeView.vue', () => {
     beforeEach(() => {
       jest.useFakeTimers();
       loadNodesPromise = new Promise(resolve => setTimeout(resolve.bind(null, generateNodes(['', ''])), 1000));
-      wrapper = createWrapper({ loadNodesAsync: () => loadNodesPromise });
+      wrapper = createWrapper({ loadNodesAsync: () => loadNodesPromise, selectionMode: SelectionMode.Single });
     });
 
     afterEach(() => {


### PR DESCRIPTION
When root tree nodes are loaded asynchronously the $_grtv_enforceSingleSelectionMode method could fire before the nodes were fully initialized. Moving this to the nextTick handler ensures this issue does not occur.