### PR TITLE
Add maxMatches parameter to getMatching

### DIFF
--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -219,15 +219,17 @@ function getCheckedRadioButtons() {
  * Gets any nodes matched by the given function.
  * @param matcherFunction {function} A function which takes a node as an argument
  * and returns a boolean indicating a match for some condition
+ * @param maxMatches {integer} The maximum number of matches to return
  * @returns {Array<TreeNode>} An array of any nodes matched by the given function
  */
-function getMatching(matcherFunction) {
+function getMatching(matcherFunction, maxMatches = 0) {
   let matches = [];
 
   if (typeof matcherFunction === 'function') {
     depthFirstTraverse((current) => {
       if (matcherFunction(current)) {
         matches.push(current);
+        return maxMatches < 1 || matches.length < maxMatches;
       }
     });
   }

--- a/src/stories/Home.stories.mdx
+++ b/src/stories/Home.stories.mdx
@@ -269,7 +269,7 @@ If specified, the `modelDefaults` property of the TreeView will be merged with n
 | getCheckedCheckboxes   | Gets models for checked checkbox nodes      |            | An `Array<Object>` of models for checked checkbox nodes     |
 | getCheckedRadioButtons | Gets models for checked radio nodes         |            | An `Array<Object>` of models for checked radio button nodes |
 | getSelected            | Gets models for selected nodes              |            | An `Array<Object>` of models for selected nodes             |
-| getMatching            | Gets models for nodes that match a function | `matcherFunction`: A function that takes a node model and returns a boolean indicating whether that node should be returned. | An `Array<Object>` of models for matched nodes |
+| getMatching            | Gets models for nodes that match a function | `matcherFunction`: A function that takes a node model and returns a boolean indicating whether that node should be returned. <br/> `maxMatches` The maximum number of matches to return. | An `Array<Object>` of models for matched nodes |
 
 ## Events
 

--- a/tests/unit/TreeView.spec.js
+++ b/tests/unit/TreeView.spec.js
@@ -138,6 +138,18 @@ describe('TreeView.vue', () => {
         expect(nodes.length).to.equal(0);
       });
     });
+
+    describe('and maxMatches argumetn is provided (> 0)', () => {
+
+      beforeEach(async () => {
+        wrapper = await createWrapper({ initialModel: generateNodes(['es', 'ES', ['es', 'eS']]), selectionMode: SelectionMode.Multiple });
+      });
+
+      it('should return up to maxMatches matches', () => {
+        let nodes = wrapper.vm.getMatching(() => true, 2);
+        expect(nodes.length).to.equal(2);
+      });
+    });
   });
 
   describe('when getSelected() is called', () => {


### PR DESCRIPTION
`getMatching` now includes an optional second parameter, `maxMatches`.

Closes #261